### PR TITLE
MBF: Quality of Life Updates.  

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .vscode/tasks.json
 TODO
 .DS_Store
+obj/
+bin/

--- a/TheOtherRoles/Helpers.cs
+++ b/TheOtherRoles/Helpers.cs
@@ -357,11 +357,11 @@ namespace TheOtherRoles {
     
         public static void shareGameVersion() {
             MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.VersionHandshake, Hazel.SendOption.Reliable, -1);
-            writer.Write((byte)TheOtherRolesPlugin.Version.Major);
-            writer.Write((byte)TheOtherRolesPlugin.Version.Minor);
-            writer.Write((byte)TheOtherRolesPlugin.Version.Build);
+            writer.WritePacked(TheOtherRolesPlugin.Version.Major);
+            writer.WritePacked(TheOtherRolesPlugin.Version.Minor);
+            writer.WritePacked(TheOtherRolesPlugin.Version.Build);
             writer.WritePacked(AmongUsClient.Instance.ClientId);
-            writer.Write((byte)(TheOtherRolesPlugin.Version.Revision < 0 ? 0xFF : TheOtherRolesPlugin.Version.Revision));
+            writer.WritePacked(TheOtherRolesPlugin.Version.Revision);
             writer.Write(Assembly.GetExecutingAssembly().ManifestModule.ModuleVersionId.ToByteArray());
             AmongUsClient.Instance.FinishRpcImmediately(writer);
             RPCProcedure.versionHandshake(TheOtherRolesPlugin.Version.Major, TheOtherRolesPlugin.Version.Minor, TheOtherRolesPlugin.Version.Build, TheOtherRolesPlugin.Version.Revision, Assembly.GetExecutingAssembly().ManifestModule.ModuleVersionId, AmongUsClient.Instance.ClientId);

--- a/TheOtherRoles/Main.cs
+++ b/TheOtherRoles/Main.cs
@@ -42,6 +42,10 @@ namespace TheOtherRoles
         public static ConfigEntry<bool> EnableHorseMode { get; set; }
         public static ConfigEntry<string> StreamerModeReplacementText { get; set; }
         public static ConfigEntry<string> StreamerModeReplacementColor { get; set; }
+        public static ConfigEntry<bool> LobbyTimer { get; set; }
+        public static ConfigEntry<string> UpdateServer { get; set; }
+        public static ConfigEntry<string> HatServerList { get; set; }
+        public static ConfigEntry<string> CustomServerList { get; set; }
         public static ConfigEntry<string> Ip { get; set; }
         public static ConfigEntry<ushort> Port { get; set; }
         public static ConfigEntry<string> ShowPopUpVersion { get; set; }
@@ -52,6 +56,16 @@ namespace TheOtherRoles
         public static void UpdateRegions() {
             ServerManager serverManager = DestroyableSingleton<ServerManager>.Instance;
             IRegionInfo[] regions = defaultRegions;
+
+            string[] servers = CustomServerList.Value.Trim().Split(',');
+            foreach(string server in servers) {
+                string[] temp = server.Trim().Split(':');
+                if(temp.Length != 3) continue;
+                var region = new DnsRegionInfo(temp[1], temp[0], StringNames.NoTranslation, temp[1], Convert.ToUInt16(temp[2]), false);
+                regions = regions.Concat(new IRegionInfo[] { region.Cast<IRegionInfo>()}).ToArray();
+            }
+            ServerManager.DefaultRegions = regions;
+            serverManager.AvailableRegions = regions;
 
             var CustomRegion = new DnsRegionInfo(Ip.Value, "Custom", StringNames.NoTranslation, Ip.Value, Port.Value, false);
             regions = regions.Concat(new IRegionInfo[] { CustomRegion.Cast<IRegionInfo>() }).ToArray();
@@ -73,7 +87,11 @@ namespace TheOtherRoles
             ShowPopUpVersion = Config.Bind("Custom", "Show PopUp", "0");
             StreamerModeReplacementText = Config.Bind("Custom", "Streamer Mode Replacement Text", "\n\nThe Other Roles");
             StreamerModeReplacementColor = Config.Bind("Custom", "Streamer Mode Replacement Text Hex Color", "#87AAF5FF");
-            
+
+            LobbyTimer = Config.Bind("Custom", "Enable Lobby Timer", true);
+            UpdateServer = Config.Bind("Custom", "Custom Update Server", "");
+            HatServerList = Config.Bind("Custom", "Custom Hat Servers", "");
+            CustomServerList = Config.Bind("Custom", "Custom Servers", "");            
 
             Ip = Config.Bind("Custom", "Custom Server IP", "127.0.0.1");
             Port = Config.Bind("Custom", "Custom Server Port", (ushort)22023);

--- a/TheOtherRoles/Modules/ModUpdater.cs
+++ b/TheOtherRoles/Modules/ModUpdater.cs
@@ -124,8 +124,9 @@ namespace TheOtherRoles.Modules {
             try {
                 HttpClient http = new HttpClient();
                 http.DefaultRequestHeaders.Add("User-Agent", "TheOtherRoles Updater");
-                var response = await http.GetAsync(new System.Uri("https://api.github.com/repos/Eisbison/TheOtherRoles/releases/latest"), HttpCompletionOption.ResponseContentRead);
-                // var response = await http.GetAsync(new System.Uri("https://api.github.com/repos/EoF-1141/TheOtherRoles/releases/latest"), HttpCompletionOption.ResponseContentRead);
+                string updateServer = "https://api.github.com/repos/Eisbison/TheOtherRoles/releases/latest";
+                if(TheOtherRolesPlugin.UpdateServer.Value.Trim() != "") updateServer = TheOtherRolesPlugin.UpdateServer.Value.Trim();
+                var response = await http.GetAsync(new System.Uri(updateServer), HttpCompletionOption.ResponseContentRead);
                 if (response.StatusCode != HttpStatusCode.OK || response.Content == null) {
                     System.Console.WriteLine("Server returned no data: " + response.StatusCode.ToString());
                     return false;

--- a/TheOtherRoles/Patches/ClientOptionsPatch.cs
+++ b/TheOtherRoles/Patches/ClientOptionsPatch.cs
@@ -20,6 +20,7 @@ namespace TheOtherRoles.Patches
             new SelectionBehaviour("Ghosts Can See Roles", () => MapOptions.ghostsSeeRoles = TheOtherRolesPlugin.GhostsSeeRoles.Value = !TheOtherRolesPlugin.GhostsSeeRoles.Value, TheOtherRolesPlugin.GhostsSeeRoles.Value),
             new SelectionBehaviour("Ghosts Can Additionally See Modifier", () => MapOptions.ghostsSeeModifier = TheOtherRolesPlugin.GhostsSeeModifier.Value = !TheOtherRolesPlugin.GhostsSeeModifier.Value, TheOtherRolesPlugin.GhostsSeeModifier.Value),
             new SelectionBehaviour("Show Role Summary", () => MapOptions.showRoleSummary = TheOtherRolesPlugin.ShowRoleSummary.Value = !TheOtherRolesPlugin.ShowRoleSummary.Value, TheOtherRolesPlugin.ShowRoleSummary.Value),
+            new SelectionBehaviour("Show Lobby Timer", () => TheOtherRolesPlugin.LobbyTimer.Value = !TheOtherRolesPlugin.LobbyTimer.Value, TheOtherRolesPlugin.LobbyTimer.Value),
             new SelectionBehaviour("Show Lighter / Darker", () => MapOptions.showLighterDarker = TheOtherRolesPlugin.ShowLighterDarker.Value = !TheOtherRolesPlugin.ShowLighterDarker.Value, TheOtherRolesPlugin.ShowLighterDarker.Value),
         };
         

--- a/TheOtherRoles/Patches/GameStartManagerPatch.cs
+++ b/TheOtherRoles/Patches/GameStartManagerPatch.cs
@@ -126,9 +126,10 @@ namespace TheOtherRoles.Patches {
                 int minutes = (int)timer / 60;
                 int seconds = (int)timer % 60;
                 string suffix = $" ({minutes:00}:{seconds:00})";
-
-                __instance.PlayerCounter.text = currentText + suffix;
-                __instance.PlayerCounter.autoSizeTextContainer = true;
+                if (TheOtherRolesPlugin.LobbyTimer.Value) {
+                    __instance.PlayerCounter.text = currentText + suffix;
+                    __instance.PlayerCounter.autoSizeTextContainer = true;
+                }
 
             }
         }

--- a/TheOtherRoles/RPC.cs
+++ b/TheOtherRoles/RPC.cs
@@ -929,21 +929,21 @@ namespace TheOtherRoles
                     RPCProcedure.setModifier(modifierId, pId, flag);
                     break;
                 case (byte)CustomRPC.VersionHandshake:
-                    byte major = reader.ReadByte();
-                    byte minor = reader.ReadByte();
-                    byte patch = reader.ReadByte();
+                    int major = reader.ReadPackedInt32();
+                    int minor = reader.ReadPackedInt32();
+                    int patch = reader.ReadPackedInt32();
                     int versionOwnerId = reader.ReadPackedInt32();
-                    byte revision = 0xFF;
+                    int revision = -1;
                     Guid guid;
                     if (reader.Length - reader.Position >= 17) { // enough bytes left to read
-                        revision = reader.ReadByte();
+                        revision = reader.ReadPackedInt32();
                         // GUID
                         byte[] gbytes = reader.ReadBytes(16);
                         guid = new Guid(gbytes);
                     } else {
                         guid = new Guid(new byte[16]);
                     }
-                    RPCProcedure.versionHandshake(major, minor, patch, revision == 0xFF ? -1 : revision, guid, versionOwnerId);
+                    RPCProcedure.versionHandshake(major, minor, patch, revision, guid, versionOwnerId);
                     break;
                 case (byte)CustomRPC.UseUncheckedVent:
                     int ventId = reader.ReadPackedInt32();


### PR DESCRIPTION
Added cfg options for CustomHatServers, CustomUpdateServers, CustomRegions, ToggleLobbyTimer.  Also updated VersionCheck code to send more than a byte so build numbers > 256 don't cause an issue.

### Use Custom Update Server
Replace the default Update Server with your own forks.
`Custom Update Server = https://example.com/amongus/latest.json`

### Add Custom Hat Server(s)
Add additional hat servers for extra hats.
`Custom Hat Servers = https://example1.com/amongus/tor_hats,https://example2.com/amongus/tor_hats,...`

### Specify Custom Impostor Servers.  
Servers will appear in Region selection similar to North America, Europe, and Asia.  This provides a clickable interface for players that play on multiple custom server regularly as well as those who can't figure out how to enter in IP addresses.
`Custom Servers = <DisplayName1>:<host1>:<port1>,<DisplayName2>:<host2>:<port2>,...`


