### PR TITLE
MBF: Dynamic Vulture count to win 

### DIFF
--- a/TheOtherRoles/Buttons.cs
+++ b/TheOtherRoles/Buttons.cs
@@ -37,7 +37,7 @@ namespace TheOtherRoles
         private static CustomButton jackalSidekickButton;
         private static CustomButton lighterButton;
         private static CustomButton eraserButton;
-        private static CustomButton placeJackInTheBoxButton;        
+        private static CustomButton placeJackInTheBoxButton;
         private static CustomButton lightsOutButton;
         public static CustomButton cleanerCleanButton;
         public static CustomButton warlockCurseButton;
@@ -63,8 +63,10 @@ namespace TheOtherRoles
         public static TMPro.TMP_Text pursuerButtonBlanksText;
         public static TMPro.TMP_Text hackerAdminTableChargesText;
         public static TMPro.TMP_Text hackerVitalsChargesText;
+        public static TMPro.TMP_Text vultureEatText;
 
-        public static void setCustomButtonCooldowns() {
+        public static void setCustomButtonCooldowns()
+        {
             engineerRepairButton.MaxTimer = 0f;
             janitorCleanButton.MaxTimer = Janitor.cooldown;
             sheriffKillButton.MaxTimer = Sheriff.cooldown;
@@ -107,7 +109,7 @@ namespace TheOtherRoles
             hackerVitalsButton.EffectDuration = Hacker.duration;
             hackerAdminTableButton.EffectDuration = Hacker.duration;
             vampireKillButton.EffectDuration = Vampire.delay;
-            lighterButton.EffectDuration = Lighter.duration; 
+            lighterButton.EffectDuration = Lighter.duration;
             camouflagerButton.EffectDuration = Camouflager.duration;
             morphlingButton.EffectDuration = Morphling.duration;
             lightsOutButton.EffectDuration = Trickster.lightsOutDuration;
@@ -121,7 +123,8 @@ namespace TheOtherRoles
             zoomOutButton.MaxTimer = 0f;
         }
 
-        public static void resetTimeMasterButton() {
+        public static void resetTimeMasterButton()
+        {
             timeMasterShieldButton.Timer = timeMasterShieldButton.MaxTimer;
             timeMasterShieldButton.isEffectActive = false;
             timeMasterShieldButton.actionButton.cooldownTimerText.color = Palette.EnabledColor;
@@ -142,11 +145,12 @@ namespace TheOtherRoles
             else
                 deputyHandcuffedButtons.Add(CachedPlayer.LocalPlayer.PlayerId, new List<CustomButton> { replacementHandcuffedButton });
         }
-        
+
         // Disables / Enables all Buttons (except the ones disabled in the Deputy class), and replaces them with new buttons.
         public static void setAllButtonsHandcuffedStatus(bool handcuffed, bool reset = false)
         {
-            if (reset) {
+            if (reset)
+            {
                 deputyHandcuffedButtons = new Dictionary<byte, List<CustomButton>>();
                 return;
             }
@@ -198,31 +202,46 @@ namespace TheOtherRoles
         {
             // Engineer Repair
             engineerRepairButton = new CustomButton(
-                () => {
+                () =>
+                {
                     engineerRepairButton.Timer = 0f;
                     MessageWriter usedRepairWriter = AmongUsClient.Instance.StartRpcImmediately(CachedPlayer.LocalPlayer.PlayerControl.NetId, (byte)CustomRPC.EngineerUsedRepair, Hazel.SendOption.Reliable, -1);
                     AmongUsClient.Instance.FinishRpcImmediately(usedRepairWriter);
                     RPCProcedure.engineerUsedRepair();
 
-                    foreach (PlayerTask task in CachedPlayer.LocalPlayer.PlayerControl.myTasks.GetFastEnumerator()) {
-                        if (task.TaskType == TaskTypes.FixLights) {
+                    foreach (PlayerTask task in CachedPlayer.LocalPlayer.PlayerControl.myTasks.GetFastEnumerator())
+                    {
+                        if (task.TaskType == TaskTypes.FixLights)
+                        {
                             MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(CachedPlayer.LocalPlayer.PlayerControl.NetId, (byte)CustomRPC.EngineerFixLights, Hazel.SendOption.Reliable, -1);
                             AmongUsClient.Instance.FinishRpcImmediately(writer);
                             RPCProcedure.engineerFixLights();
-                        } else if (task.TaskType == TaskTypes.RestoreOxy) {
+                        }
+                        else if (task.TaskType == TaskTypes.RestoreOxy)
+                        {
                             MapUtilities.CachedShipStatus.RpcRepairSystem(SystemTypes.LifeSupp, 0 | 64);
                             MapUtilities.CachedShipStatus.RpcRepairSystem(SystemTypes.LifeSupp, 1 | 64);
-                        } else if (task.TaskType == TaskTypes.ResetReactor) {
+                        }
+                        else if (task.TaskType == TaskTypes.ResetReactor)
+                        {
                             MapUtilities.CachedShipStatus.RpcRepairSystem(SystemTypes.Reactor, 16);
-                        } else if (task.TaskType == TaskTypes.ResetSeismic) {
+                        }
+                        else if (task.TaskType == TaskTypes.ResetSeismic)
+                        {
                             MapUtilities.CachedShipStatus.RpcRepairSystem(SystemTypes.Laboratory, 16);
-                        } else if (task.TaskType == TaskTypes.FixComms) {
+                        }
+                        else if (task.TaskType == TaskTypes.FixComms)
+                        {
                             MapUtilities.CachedShipStatus.RpcRepairSystem(SystemTypes.Comms, 16 | 0);
                             MapUtilities.CachedShipStatus.RpcRepairSystem(SystemTypes.Comms, 16 | 1);
-                        } else if (task.TaskType == TaskTypes.StopCharles) {
+                        }
+                        else if (task.TaskType == TaskTypes.StopCharles)
+                        {
                             MapUtilities.CachedShipStatus.RpcRepairSystem(SystemTypes.Reactor, 0 | 16);
                             MapUtilities.CachedShipStatus.RpcRepairSystem(SystemTypes.Reactor, 1 | 16);
-                        } else if (SubmergedCompatibility.IsSubmerged && task.TaskType == SubmergedCompatibility.RetrieveOxygenMask) {
+                        }
+                        else if (SubmergedCompatibility.IsSubmerged && task.TaskType == SubmergedCompatibility.RetrieveOxygenMask)
+                        {
                             MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(CachedPlayer.LocalPlayer.PlayerControl.NetId, (byte)CustomRPC.EngineerFixSubmergedOxygen, Hazel.SendOption.Reliable, -1);
                             AmongUsClient.Instance.FinishRpcImmediately(writer);
                             RPCProcedure.engineerFixSubmergedOxygen();
@@ -231,7 +250,8 @@ namespace TheOtherRoles
                     }
                 },
                 () => { return Engineer.engineer != null && Engineer.engineer == CachedPlayer.LocalPlayer.PlayerControl && Engineer.remainingFixes > 0 && !CachedPlayer.LocalPlayer.Data.IsDead; },
-                () => {
+                () =>
+                {
                     bool sabotageActive = false;
                     foreach (PlayerTask task in CachedPlayer.LocalPlayer.PlayerControl.myTasks.GetFastEnumerator())
                         if (task.TaskType == TaskTypes.FixLights || task.TaskType == TaskTypes.RestoreOxy || task.TaskType == TaskTypes.ResetReactor || task.TaskType == TaskTypes.ResetSeismic || task.TaskType == TaskTypes.FixComms || task.TaskType == TaskTypes.StopCharles
@@ -239,7 +259,7 @@ namespace TheOtherRoles
                             sabotageActive = true;
                     return sabotageActive && Engineer.remainingFixes > 0 && CachedPlayer.LocalPlayer.PlayerControl.CanMove;
                 },
-                () => {},
+                () => { },
                 Engineer.getButtonSprite(),
                 new Vector3(-1.8f, -0.06f, 0),
                 __instance,
@@ -248,8 +268,10 @@ namespace TheOtherRoles
 
             // Janitor Clean
             janitorCleanButton = new CustomButton(
-                () => {
-                    foreach (Collider2D collider2D in Physics2D.OverlapCircleAll(CachedPlayer.LocalPlayer.PlayerControl.GetTruePosition(), CachedPlayer.LocalPlayer.PlayerControl.MaxReportDistance, Constants.PlayersOnlyMask)) {
+                () =>
+                {
+                    foreach (Collider2D collider2D in Physics2D.OverlapCircleAll(CachedPlayer.LocalPlayer.PlayerControl.GetTruePosition(), CachedPlayer.LocalPlayer.PlayerControl.MaxReportDistance, Constants.PlayersOnlyMask))
+                    {
                         if (collider2D.tag == "DeadBody")
                         {
                             DeadBody component = collider2D.GetComponent<DeadBody>();
@@ -284,19 +306,23 @@ namespace TheOtherRoles
 
             // Sheriff Kill
             sheriffKillButton = new CustomButton(
-                () => {
+                () =>
+                {
                     MurderAttemptResult murderAttemptResult = Helpers.checkMuderAttempt(Sheriff.sheriff, Sheriff.currentTarget);
                     if (murderAttemptResult == MurderAttemptResult.SuppressKill) return;
 
-                    if (murderAttemptResult == MurderAttemptResult.PerformKill) {
+                    if (murderAttemptResult == MurderAttemptResult.PerformKill)
+                    {
                         byte targetId = 0;
                         if ((Sheriff.currentTarget.Data.Role.IsImpostor && (Sheriff.currentTarget != Mini.mini || Mini.isGrownUp())) ||
                             (Sheriff.spyCanDieToSheriff && Spy.spy == Sheriff.currentTarget) ||
                             (Sheriff.canKillNeutrals && (Arsonist.arsonist == Sheriff.currentTarget || Jester.jester == Sheriff.currentTarget || Vulture.vulture == Sheriff.currentTarget || Lawyer.lawyer == Sheriff.currentTarget || Pursuer.pursuer == Sheriff.currentTarget)) ||
-                            (Jackal.jackal == Sheriff.currentTarget || Sidekick.sidekick == Sheriff.currentTarget)) {
+                            (Jackal.jackal == Sheriff.currentTarget || Sidekick.sidekick == Sheriff.currentTarget))
+                        {
                             targetId = Sheriff.currentTarget.PlayerId;
                         }
-                        else {
+                        else
+                        {
                             targetId = CachedPlayer.LocalPlayer.PlayerId;
                         }
 
@@ -313,7 +339,7 @@ namespace TheOtherRoles
                 },
                 () => { return Sheriff.sheriff != null && Sheriff.sheriff == CachedPlayer.LocalPlayer.PlayerControl && !CachedPlayer.LocalPlayer.Data.IsDead; },
                 () => { return Sheriff.currentTarget && CachedPlayer.LocalPlayer.PlayerControl.CanMove; },
-                () => { sheriffKillButton.Timer = sheriffKillButton.MaxTimer;},
+                () => { sheriffKillButton.Timer = sheriffKillButton.MaxTimer; },
                 __instance.KillButton.graphic.sprite,
                 new Vector3(0f, 1f, 0),
                 __instance,
@@ -322,7 +348,8 @@ namespace TheOtherRoles
 
             // Deputy Handcuff
             deputyHandcuffButton = new CustomButton(
-                () => {
+                () =>
+                {
                     byte targetId = 0;
                     targetId = Sheriff.sheriff == CachedPlayer.LocalPlayer.PlayerControl ? Sheriff.currentTarget.PlayerId : Deputy.currentTarget.PlayerId;  // If the deputy is now the sheriff, sheriffs target, else deputies target
 
@@ -334,7 +361,8 @@ namespace TheOtherRoles
                     deputyHandcuffButton.Timer = deputyHandcuffButton.MaxTimer;
                 },
                 () => { return (Deputy.deputy != null && Deputy.deputy == CachedPlayer.LocalPlayer.PlayerControl || Sheriff.sheriff != null && Sheriff.sheriff == CachedPlayer.LocalPlayer.PlayerControl && Sheriff.sheriff == Sheriff.formerDeputy && Deputy.keepsHandcuffsOnPromotion) && !CachedPlayer.LocalPlayer.Data.IsDead; },
-                () => {
+                () =>
+                {
                     if (deputyButtonHandcuffsText != null) deputyButtonHandcuffsText.text = $"{Deputy.remainingHandcuffs}";
                     return ((Deputy.deputy != null && Deputy.deputy == CachedPlayer.LocalPlayer.PlayerControl && Deputy.currentTarget || Sheriff.sheriff != null && Sheriff.sheriff == CachedPlayer.LocalPlayer.PlayerControl && Sheriff.sheriff == Sheriff.formerDeputy && Sheriff.currentTarget) && Deputy.remainingHandcuffs > 0 && CachedPlayer.LocalPlayer.PlayerControl.CanMove);
                 },
@@ -353,14 +381,16 @@ namespace TheOtherRoles
 
             // Time Master Rewind Time
             timeMasterShieldButton = new CustomButton(
-                () => {
+                () =>
+                {
                     MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(CachedPlayer.LocalPlayer.PlayerControl.NetId, (byte)CustomRPC.TimeMasterShield, Hazel.SendOption.Reliable, -1);
                     AmongUsClient.Instance.FinishRpcImmediately(writer);
                     RPCProcedure.timeMasterShield();
                 },
                 () => { return TimeMaster.timeMaster != null && TimeMaster.timeMaster == CachedPlayer.LocalPlayer.PlayerControl && !CachedPlayer.LocalPlayer.Data.IsDead; },
                 () => { return CachedPlayer.LocalPlayer.PlayerControl.CanMove; },
-                () => {
+                () =>
+                {
                     timeMasterShieldButton.Timer = timeMasterShieldButton.MaxTimer;
                     timeMasterShieldButton.isEffectActive = false;
                     timeMasterShieldButton.actionButton.cooldownTimerText.color = Palette.EnabledColor;
@@ -368,7 +398,7 @@ namespace TheOtherRoles
                 TimeMaster.getButtonSprite(),
                 new Vector3(-1.8f, -0.06f, 0),
                 __instance,
-                KeyCode.F, 
+                KeyCode.F,
                 true,
                 TimeMaster.shieldDuration,
                 () => { timeMasterShieldButton.Timer = timeMasterShieldButton.MaxTimer; }
@@ -376,9 +406,10 @@ namespace TheOtherRoles
 
             // Medic Shield
             medicShieldButton = new CustomButton(
-                () => {
+                () =>
+                {
                     medicShieldButton.Timer = 0f;
- 
+
                     MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(CachedPlayer.LocalPlayer.PlayerControl.NetId, Medic.setShieldAfterMeeting ? (byte)CustomRPC.SetFutureShielded : (byte)CustomRPC.MedicSetShielded, Hazel.SendOption.Reliable, -1);
                     writer.Write(Medic.currentTarget.PlayerId);
                     AmongUsClient.Instance.FinishRpcImmediately(writer);
@@ -390,17 +421,18 @@ namespace TheOtherRoles
                 },
                 () => { return Medic.medic != null && Medic.medic == CachedPlayer.LocalPlayer.PlayerControl && !CachedPlayer.LocalPlayer.Data.IsDead; },
                 () => { return !Medic.usedShield && Medic.currentTarget && CachedPlayer.LocalPlayer.PlayerControl.CanMove; },
-                () => {},
+                () => { },
                 Medic.getButtonSprite(),
                 new Vector3(-1.8f, -0.06f, 0),
                 __instance,
                 KeyCode.F
             );
 
-            
+
             // Shifter shift
             shifterShiftButton = new CustomButton(
-                () => {
+                () =>
+                {
                     MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(CachedPlayer.LocalPlayer.PlayerControl.NetId, (byte)CustomRPC.SetFutureShifted, Hazel.SendOption.Reliable, -1);
                     writer.Write(Shifter.currentTarget.PlayerId);
                     AmongUsClient.Instance.FinishRpcImmediately(writer);
@@ -416,10 +448,12 @@ namespace TheOtherRoles
             );
 
             // Morphling morph
-            
+
             morphlingButton = new CustomButton(
-                () => {
-                    if (Morphling.sampledTarget != null) {
+                () =>
+                {
+                    if (Morphling.sampledTarget != null)
+                    {
                         MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(CachedPlayer.LocalPlayer.PlayerControl.NetId, (byte)CustomRPC.MorphlingMorph, Hazel.SendOption.Reliable, -1);
                         writer.Write(Morphling.sampledTarget.PlayerId);
                         AmongUsClient.Instance.FinishRpcImmediately(writer);
@@ -427,7 +461,9 @@ namespace TheOtherRoles
                         Morphling.sampledTarget = null;
                         morphlingButton.EffectDuration = Morphling.duration;
 
-                    } else if (Morphling.currentTarget != null) {
+                    }
+                    else if (Morphling.currentTarget != null)
+                    {
                         Morphling.sampledTarget = Morphling.currentTarget;
                         morphlingButton.Sprite = Morphling.getMorphSprite();
                         morphlingButton.EffectDuration = 1f;
@@ -449,13 +485,15 @@ namespace TheOtherRoles
                 },
                 () => { return Morphling.morphling != null && Morphling.morphling == CachedPlayer.LocalPlayer.PlayerControl && !CachedPlayer.LocalPlayer.Data.IsDead; },
                 () => { return (Morphling.currentTarget || Morphling.sampledTarget) && CachedPlayer.LocalPlayer.PlayerControl.CanMove; },
-                () => { 
+                () =>
+                {
                     morphlingButton.Timer = morphlingButton.MaxTimer;
                     morphlingButton.Sprite = Morphling.getSampleSprite();
                     morphlingButton.isEffectActive = false;
                     morphlingButton.actionButton.cooldownTimerText.color = Palette.EnabledColor;
                     Morphling.sampledTarget = null;
-                    if (morphTargetDisplay != null) {  // Reset the poolable player
+                    if (morphTargetDisplay != null)
+                    {  // Reset the poolable player
                         morphTargetDisplay.gameObject.SetActive(false);
                         GameObject.Destroy(morphTargetDisplay.gameObject);
                         morphTargetDisplay = null;
@@ -467,8 +505,10 @@ namespace TheOtherRoles
                 KeyCode.F,
                 true,
                 Morphling.duration,
-                () => {
-                    if (Morphling.sampledTarget == null) {
+                () =>
+                {
+                    if (Morphling.sampledTarget == null)
+                    {
                         morphlingButton.Timer = morphlingButton.MaxTimer;
                         morphlingButton.Sprite = Morphling.getSampleSprite();
 
@@ -482,14 +522,16 @@ namespace TheOtherRoles
 
             // Camouflager camouflage
             camouflagerButton = new CustomButton(
-                () => {
+                () =>
+                {
                     MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(CachedPlayer.LocalPlayer.PlayerControl.NetId, (byte)CustomRPC.CamouflagerCamouflage, Hazel.SendOption.Reliable, -1);
                     AmongUsClient.Instance.FinishRpcImmediately(writer);
                     RPCProcedure.camouflagerCamouflage();
                 },
                 () => { return Camouflager.camouflager != null && Camouflager.camouflager == CachedPlayer.LocalPlayer.PlayerControl && !CachedPlayer.LocalPlayer.Data.IsDead; },
                 () => { return CachedPlayer.LocalPlayer.PlayerControl.CanMove; },
-                () => {
+                () =>
+                {
                     camouflagerButton.Timer = camouflagerButton.MaxTimer;
                     camouflagerButton.isEffectActive = false;
                     camouflagerButton.actionButton.cooldownTimerText.color = Palette.EnabledColor;
@@ -505,12 +547,14 @@ namespace TheOtherRoles
 
             // Hacker button
             hackerButton = new CustomButton(
-                () => {
+                () =>
+                {
                     Hacker.hackerTimer = Hacker.duration;
                 },
                 () => { return Hacker.hacker != null && Hacker.hacker == CachedPlayer.LocalPlayer.PlayerControl && !CachedPlayer.LocalPlayer.Data.IsDead; },
                 () => { return true; },
-                () => {
+                () =>
+                {
                     hackerButton.Timer = hackerButton.MaxTimer;
                     hackerButton.isEffectActive = false;
                     hackerButton.actionButton.cooldownTimerText.color = Palette.EnabledColor;
@@ -521,11 +565,12 @@ namespace TheOtherRoles
                 KeyCode.F,
                 true,
                 0f,
-                () => { hackerButton.Timer = hackerButton.MaxTimer;}
+                () => { hackerButton.Timer = hackerButton.MaxTimer; }
             );
 
             hackerAdminTableButton = new CustomButton(
-               () => {
+               () =>
+               {
                    if (!MapBehaviour.Instance || !MapBehaviour.Instance.isActiveAndEnabled)
                        FastDestroyableSingleton<HudManager>.Instance.ShowMap((System.Action<MapBehaviour>)(m => m.ShowCountOverlay()));
 
@@ -533,12 +578,14 @@ namespace TheOtherRoles
                    CachedPlayer.LocalPlayer.NetTransform.Halt(); // Stop current movement 
                    Hacker.chargesAdminTable--;
                },
-               () => { return Hacker.hacker != null && Hacker.hacker == CachedPlayer.LocalPlayer.PlayerControl && !CachedPlayer.LocalPlayer.Data.IsDead;},
-               () => {
+               () => { return Hacker.hacker != null && Hacker.hacker == CachedPlayer.LocalPlayer.PlayerControl && !CachedPlayer.LocalPlayer.Data.IsDead; },
+               () =>
+               {
                    if (hackerAdminTableChargesText != null) hackerAdminTableChargesText.text = $"{Hacker.chargesAdminTable} / {Hacker.toolsNumber}";
-                   return Hacker.chargesAdminTable > 0; 
+                   return Hacker.chargesAdminTable > 0;
                },
-               () => {
+               () =>
+               {
                    hackerAdminTableButton.Timer = hackerAdminTableButton.MaxTimer;
                    hackerAdminTableButton.isEffectActive = false;
                    hackerAdminTableButton.actionButton.cooldownTimerText.color = Palette.EnabledColor;
@@ -549,7 +596,8 @@ namespace TheOtherRoles
                KeyCode.Q,
                true,
                0f,
-               () => { 
+               () =>
+               {
                    hackerAdminTableButton.Timer = hackerAdminTableButton.MaxTimer;
                    if (!hackerVitalsButton.isEffectActive) CachedPlayer.LocalPlayer.PlayerControl.moveable = true;
                    if (MapBehaviour.Instance && MapBehaviour.Instance.isActiveAndEnabled) MapBehaviour.Instance.Close();
@@ -566,9 +614,12 @@ namespace TheOtherRoles
             hackerAdminTableChargesText.transform.localPosition += new Vector3(-0.05f, 0.7f, 0);
 
             hackerVitalsButton = new CustomButton(
-               () => {
-                   if (PlayerControl.GameOptions.MapId != 1) {
-                       if (Hacker.vitals == null) {
+               () =>
+               {
+                   if (PlayerControl.GameOptions.MapId != 1)
+                   {
+                       if (Hacker.vitals == null)
+                       {
                            var e = UnityEngine.Object.FindObjectsOfType<SystemConsole>().FirstOrDefault(x => x.gameObject.name.Contains("panel_vitals"));
                            if (e == null || Camera.main == null) return;
                            Hacker.vitals = UnityEngine.Object.Instantiate(e.MinigamePrefab, Camera.main.transform, false);
@@ -576,8 +627,11 @@ namespace TheOtherRoles
                        Hacker.vitals.transform.SetParent(Camera.main.transform, false);
                        Hacker.vitals.transform.localPosition = new Vector3(0.0f, 0.0f, -50f);
                        Hacker.vitals.Begin(null);
-                   } else {
-                       if (Hacker.doorLog == null) {
+                   }
+                   else
+                   {
+                       if (Hacker.doorLog == null)
+                       {
                            var e = UnityEngine.Object.FindObjectsOfType<SystemConsole>().FirstOrDefault(x => x.gameObject.name.Contains("SurvLogConsole"));
                            if (e == null || Camera.main == null) return;
                            Hacker.doorLog = UnityEngine.Object.Instantiate(e.MinigamePrefab, Camera.main.transform, false);
@@ -593,13 +647,15 @@ namespace TheOtherRoles
                    Hacker.chargesVitals--;
                },
                () => { return Hacker.hacker != null && Hacker.hacker == CachedPlayer.LocalPlayer.PlayerControl && !CachedPlayer.LocalPlayer.Data.IsDead && PlayerControl.GameOptions.MapId != 0 && PlayerControl.GameOptions.MapId != 3; },
-               () => {
+               () =>
+               {
                    if (hackerVitalsChargesText != null) hackerVitalsChargesText.text = $"{Hacker.chargesVitals} / {Hacker.toolsNumber}";
                    hackerVitalsButton.actionButton.graphic.sprite = PlayerControl.GameOptions.MapId == 1 ? Hacker.getLogSprite() : Hacker.getVitalsSprite();
                    hackerVitalsButton.actionButton.OverrideText(PlayerControl.GameOptions.MapId == 1 ? "DOORLOG" : "VITALS");
                    return Hacker.chargesVitals > 0;
                },
-               () => {
+               () =>
+               {
                    hackerVitalsButton.Timer = hackerVitalsButton.MaxTimer;
                    hackerVitalsButton.isEffectActive = false;
                    hackerVitalsButton.actionButton.cooldownTimerText.color = Palette.EnabledColor;
@@ -610,10 +666,12 @@ namespace TheOtherRoles
                KeyCode.Q,
                true,
                0f,
-               () => { 
+               () =>
+               {
                    hackerVitalsButton.Timer = hackerVitalsButton.MaxTimer;
-                   if(!hackerAdminTableButton.isEffectActive) CachedPlayer.LocalPlayer.PlayerControl.moveable = true;
-                   if (Minigame.Instance) {
+                   if (!hackerAdminTableButton.isEffectActive) CachedPlayer.LocalPlayer.PlayerControl.moveable = true;
+                   if (Minigame.Instance)
+                   {
                        if (PlayerControl.GameOptions.MapId == 1) Hacker.doorLog.ForceClose();
                        else Hacker.vitals.ForceClose();
                    }
@@ -631,7 +689,8 @@ namespace TheOtherRoles
 
             // Tracker button
             trackerTrackPlayerButton = new CustomButton(
-                () => {
+                () =>
+                {
                     MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(CachedPlayer.LocalPlayer.PlayerControl.NetId, (byte)CustomRPC.TrackerUsedTracker, Hazel.SendOption.Reliable, -1);
                     writer.Write(Tracker.currentTarget.PlayerId);
                     AmongUsClient.Instance.FinishRpcImmediately(writer);
@@ -639,7 +698,7 @@ namespace TheOtherRoles
                 },
                 () => { return Tracker.tracker != null && Tracker.tracker == CachedPlayer.LocalPlayer.PlayerControl && !CachedPlayer.LocalPlayer.Data.IsDead; },
                 () => { return CachedPlayer.LocalPlayer.PlayerControl.CanMove && Tracker.currentTarget != null && !Tracker.usedTracker; },
-                () => { if(Tracker.resetTargetAfterMeeting) Tracker.resetTracked(); },
+                () => { if (Tracker.resetTargetAfterMeeting) Tracker.resetTracked(); },
                 Tracker.getButtonSprite(),
                 new Vector3(-1.8f, -0.06f, 0),
                 __instance,
@@ -650,7 +709,8 @@ namespace TheOtherRoles
                 () => { Tracker.corpsesTrackingTimer = Tracker.corpsesTrackingDuration; },
                 () => { return Tracker.tracker != null && Tracker.tracker == CachedPlayer.LocalPlayer.PlayerControl && !CachedPlayer.LocalPlayer.Data.IsDead && Tracker.canTrackCorpses; },
                 () => { return CachedPlayer.LocalPlayer.PlayerControl.CanMove; },
-                () => {
+                () =>
+                {
                     trackerTrackCorpsesButton.Timer = trackerTrackCorpsesButton.MaxTimer;
                     trackerTrackCorpsesButton.isEffectActive = false;
                     trackerTrackCorpsesButton.actionButton.cooldownTimerText.color = Palette.EnabledColor;
@@ -661,16 +721,20 @@ namespace TheOtherRoles
                 KeyCode.Q,
                 true,
                 Tracker.corpsesTrackingDuration,
-                () => {
+                () =>
+                {
                     trackerTrackCorpsesButton.Timer = trackerTrackCorpsesButton.MaxTimer;
                 }
             );
-    
+
             vampireKillButton = new CustomButton(
-                () => {
+                () =>
+                {
                     MurderAttemptResult murder = Helpers.checkMuderAttempt(Vampire.vampire, Vampire.currentTarget);
-                    if (murder == MurderAttemptResult.PerformKill) {
-                        if (Vampire.targetNearGarlic) {
+                    if (murder == MurderAttemptResult.PerformKill)
+                    {
+                        if (Vampire.targetNearGarlic)
+                        {
                             MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(CachedPlayer.LocalPlayer.PlayerControl.NetId, (byte)CustomRPC.UncheckedMurderPlayer, Hazel.SendOption.Reliable, -1);
                             writer.Write(Vampire.vampire.PlayerId);
                             writer.Write(Vampire.currentTarget.PlayerId);
@@ -680,7 +744,9 @@ namespace TheOtherRoles
 
                             vampireKillButton.HasEffect = false; // Block effect on this click
                             vampireKillButton.Timer = vampireKillButton.MaxTimer;
-                        } else {
+                        }
+                        else
+                        {
                             Vampire.bitten = Vampire.currentTarget;
                             // Notify players about bitten
                             MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(CachedPlayer.LocalPlayer.PlayerControl.NetId, (byte)CustomRPC.VampireSetBitten, Hazel.SendOption.Reliable, -1);
@@ -689,8 +755,10 @@ namespace TheOtherRoles
                             AmongUsClient.Instance.FinishRpcImmediately(writer);
                             RPCProcedure.vampireSetBitten(Vampire.bitten.PlayerId, 0);
 
-                            FastDestroyableSingleton<HudManager>.Instance.StartCoroutine(Effects.Lerp(Vampire.delay, new Action<float>((p) => { // Delayed action
-                                if (p == 1f) {
+                            FastDestroyableSingleton<HudManager>.Instance.StartCoroutine(Effects.Lerp(Vampire.delay, new Action<float>((p) =>
+                            { // Delayed action
+                                if (p == 1f)
+                                {
                                     // Perform kill if possible and reset bitten (regardless whether the kill was successful or not)
                                     Helpers.checkMuderAttemptAndKill(Vampire.vampire, Vampire.bitten, showAnimation: false);
                                     MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(CachedPlayer.LocalPlayer.PlayerControl.NetId, (byte)CustomRPC.VampireSetBitten, Hazel.SendOption.Reliable, -1);
@@ -703,26 +771,34 @@ namespace TheOtherRoles
 
                             vampireKillButton.HasEffect = true; // Trigger effect on this click
                         }
-                    } else if (murder == MurderAttemptResult.BlankKill) {
+                    }
+                    else if (murder == MurderAttemptResult.BlankKill)
+                    {
                         vampireKillButton.Timer = vampireKillButton.MaxTimer;
                         vampireKillButton.HasEffect = false;
-                    } else {
+                    }
+                    else
+                    {
                         vampireKillButton.HasEffect = false;
                     }
                 },
                 () => { return Vampire.vampire != null && Vampire.vampire == CachedPlayer.LocalPlayer.PlayerControl && !CachedPlayer.LocalPlayer.Data.IsDead; },
-                () => {
-                    if (Vampire.targetNearGarlic && Vampire.canKillNearGarlics) {
+                () =>
+                {
+                    if (Vampire.targetNearGarlic && Vampire.canKillNearGarlics)
+                    {
                         vampireKillButton.actionButton.graphic.sprite = __instance.KillButton.graphic.sprite;
                         vampireKillButton.showButtonText = true;
                     }
-                    else {
+                    else
+                    {
                         vampireKillButton.actionButton.graphic.sprite = Vampire.getButtonSprite();
                         vampireKillButton.showButtonText = false;
                     }
                     return Vampire.currentTarget != null && CachedPlayer.LocalPlayer.PlayerControl.CanMove && (!Vampire.targetNearGarlic || Vampire.canKillNearGarlics);
                 },
-                () => {
+                () =>
+                {
                     vampireKillButton.Timer = vampireKillButton.MaxTimer;
                     vampireKillButton.isEffectActive = false;
                     vampireKillButton.actionButton.cooldownTimerText.color = Palette.EnabledColor;
@@ -733,23 +809,25 @@ namespace TheOtherRoles
                 KeyCode.Q,
                 false,
                 0f,
-                () => {
+                () =>
+                {
                     vampireKillButton.Timer = vampireKillButton.MaxTimer;
                 }
             );
 
             garlicButton = new CustomButton(
-                () => {
+                () =>
+                {
                     Vampire.localPlacedGarlic = true;
                     var pos = CachedPlayer.LocalPlayer.transform.position;
                     byte[] buff = new byte[sizeof(float) * 2];
-                    Buffer.BlockCopy(BitConverter.GetBytes(pos.x), 0, buff, 0*sizeof(float), sizeof(float));
-                    Buffer.BlockCopy(BitConverter.GetBytes(pos.y), 0, buff, 1*sizeof(float), sizeof(float));
+                    Buffer.BlockCopy(BitConverter.GetBytes(pos.x), 0, buff, 0 * sizeof(float), sizeof(float));
+                    Buffer.BlockCopy(BitConverter.GetBytes(pos.y), 0, buff, 1 * sizeof(float), sizeof(float));
 
                     MessageWriter writer = AmongUsClient.Instance.StartRpc(CachedPlayer.LocalPlayer.PlayerControl.NetId, (byte)CustomRPC.PlaceGarlic, Hazel.SendOption.Reliable);
                     writer.WriteBytesAndSize(buff);
                     writer.EndMessage();
-                    RPCProcedure.placeGarlic(buff); 
+                    RPCProcedure.placeGarlic(buff);
                 },
                 () => { return !Vampire.localPlacedGarlic && !CachedPlayer.LocalPlayer.Data.IsDead && Vampire.garlicsActive; },
                 () => { return CachedPlayer.LocalPlayer.PlayerControl.CanMove && !Vampire.localPlacedGarlic; },
@@ -762,7 +840,8 @@ namespace TheOtherRoles
             );
 
             portalmakerPlacePortalButton = new CustomButton(
-                () => {
+                () =>
+                {
                     portalmakerPlacePortalButton.Timer = portalmakerPlacePortalButton.MaxTimer;
 
                     var pos = CachedPlayer.LocalPlayer.transform.position;
@@ -785,34 +864,40 @@ namespace TheOtherRoles
             );
 
             usePortalButton = new CustomButton(
-                () => {
+                () =>
+                {
                     bool didTeleport = false;
                     Vector3 exit = Portal.findExit(CachedPlayer.LocalPlayer.transform.position);
                     Vector3 entry = Portal.findEntry(CachedPlayer.LocalPlayer.transform.position);
                     CachedPlayer.LocalPlayer.NetTransform.RpcSnapTo(entry);
 
-                    if (!CachedPlayer.LocalPlayer.Data.IsDead) {  // Ghosts can portal too, but non-blocking and only with a local animation
+                    if (!CachedPlayer.LocalPlayer.Data.IsDead)
+                    {  // Ghosts can portal too, but non-blocking and only with a local animation
                         MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(CachedPlayer.LocalPlayer.PlayerControl.NetId, (byte)CustomRPC.UsePortal, Hazel.SendOption.Reliable, -1);
                         writer.Write((byte)CachedPlayer.LocalPlayer.PlayerId);
                         AmongUsClient.Instance.FinishRpcImmediately(writer);
                     }
                     RPCProcedure.usePortal(CachedPlayer.LocalPlayer.PlayerId);
                     usePortalButton.Timer = usePortalButton.MaxTimer;
-                    FastDestroyableSingleton<HudManager>.Instance.StartCoroutine(Effects.Lerp(Portal.teleportDuration, new Action<float>((p) => { // Delayed action
+                    FastDestroyableSingleton<HudManager>.Instance.StartCoroutine(Effects.Lerp(Portal.teleportDuration, new Action<float>((p) =>
+                    { // Delayed action
                         CachedPlayer.LocalPlayer.PlayerControl.moveable = false;
                         CachedPlayer.LocalPlayer.NetTransform.Halt();
-                        if (p >= 0.5f && p <= 0.53f && !didTeleport && !MeetingHud.Instance) {
-                            if (SubmergedCompatibility.IsSubmerged) {
+                        if (p >= 0.5f && p <= 0.53f && !didTeleport && !MeetingHud.Instance)
+                        {
+                            if (SubmergedCompatibility.IsSubmerged)
+                            {
                                 SubmergedCompatibility.ChangeFloor(exit.y > -7);
                             }
                             CachedPlayer.LocalPlayer.NetTransform.RpcSnapTo(exit);
                             didTeleport = true;
                         }
-                        if (p == 1f) {
+                        if (p == 1f)
+                        {
                             CachedPlayer.LocalPlayer.PlayerControl.moveable = true;
                         }
                     })));
-                    },
+                },
                 () => { return Portal.bothPlacedAndEnabled; },
                 () => { return CachedPlayer.LocalPlayer.PlayerControl.CanMove && Portal.locationNearEntry(CachedPlayer.LocalPlayer.transform.position) && !Portal.isTeleporting; },
                 () => { usePortalButton.Timer = usePortalButton.MaxTimer; },
@@ -825,7 +910,8 @@ namespace TheOtherRoles
 
             // Jackal Sidekick Button
             jackalSidekickButton = new CustomButton(
-                () => {
+                () =>
+                {
                     MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(CachedPlayer.LocalPlayer.PlayerControl.NetId, (byte)CustomRPC.JackalCreatesSidekick, Hazel.SendOption.Reliable, -1);
                     writer.Write(Jackal.currentTarget.PlayerId);
                     AmongUsClient.Instance.FinishRpcImmediately(writer);
@@ -833,7 +919,7 @@ namespace TheOtherRoles
                 },
                 () => { return Jackal.canCreateSidekick && Jackal.jackal != null && Jackal.jackal == CachedPlayer.LocalPlayer.PlayerControl && !CachedPlayer.LocalPlayer.Data.IsDead; },
                 () => { return Jackal.canCreateSidekick && Jackal.currentTarget != null && CachedPlayer.LocalPlayer.PlayerControl.CanMove; },
-                () => { jackalSidekickButton.Timer = jackalSidekickButton.MaxTimer;},
+                () => { jackalSidekickButton.Timer = jackalSidekickButton.MaxTimer; },
                 Jackal.getSidekickButtonSprite(),
                 new Vector3(-1.8f, -0.06f, 0),
                 __instance,
@@ -842,31 +928,33 @@ namespace TheOtherRoles
 
             // Jackal Kill
             jackalKillButton = new CustomButton(
-                () => {
+                () =>
+                {
                     if (Helpers.checkMuderAttemptAndKill(Jackal.jackal, Jackal.currentTarget) == MurderAttemptResult.SuppressKill) return;
 
-                    jackalKillButton.Timer = jackalKillButton.MaxTimer; 
+                    jackalKillButton.Timer = jackalKillButton.MaxTimer;
                     Jackal.currentTarget = null;
                 },
                 () => { return Jackal.jackal != null && Jackal.jackal == CachedPlayer.LocalPlayer.PlayerControl && !CachedPlayer.LocalPlayer.Data.IsDead; },
                 () => { return Jackal.currentTarget && CachedPlayer.LocalPlayer.PlayerControl.CanMove; },
-                () => { jackalKillButton.Timer = jackalKillButton.MaxTimer;},
+                () => { jackalKillButton.Timer = jackalKillButton.MaxTimer; },
                 __instance.KillButton.graphic.sprite,
                 new Vector3(0, 1f, 0),
                 __instance,
                 KeyCode.Q
             );
-            
+
             // Sidekick Kill
             sidekickKillButton = new CustomButton(
-                () => {
+                () =>
+                {
                     if (Helpers.checkMuderAttemptAndKill(Sidekick.sidekick, Sidekick.currentTarget) == MurderAttemptResult.SuppressKill) return;
-                    sidekickKillButton.Timer = sidekickKillButton.MaxTimer; 
+                    sidekickKillButton.Timer = sidekickKillButton.MaxTimer;
                     Sidekick.currentTarget = null;
                 },
                 () => { return Sidekick.canKill && Sidekick.sidekick != null && Sidekick.sidekick == CachedPlayer.LocalPlayer.PlayerControl && !CachedPlayer.LocalPlayer.Data.IsDead; },
                 () => { return Sidekick.currentTarget && CachedPlayer.LocalPlayer.PlayerControl.CanMove; },
-                () => { sidekickKillButton.Timer = sidekickKillButton.MaxTimer;},
+                () => { sidekickKillButton.Timer = sidekickKillButton.MaxTimer; },
                 __instance.KillButton.graphic.sprite,
                 new Vector3(0, 1f, 0),
                 __instance,
@@ -875,12 +963,14 @@ namespace TheOtherRoles
 
             // Lighter light
             lighterButton = new CustomButton(
-                () => {
+                () =>
+                {
                     Lighter.lighterTimer = Lighter.duration;
                 },
                 () => { return Lighter.lighter != null && Lighter.lighter == CachedPlayer.LocalPlayer.PlayerControl && !CachedPlayer.LocalPlayer.Data.IsDead; },
                 () => { return CachedPlayer.LocalPlayer.PlayerControl.CanMove; },
-                () => {
+                () =>
+                {
                     lighterButton.Timer = lighterButton.MaxTimer;
                     lighterButton.isEffectActive = false;
                     lighterButton.actionButton.graphic.color = Palette.EnabledColor;
@@ -896,7 +986,8 @@ namespace TheOtherRoles
 
             // Eraser erase button
             eraserButton = new CustomButton(
-                () => {
+                () =>
+                {
                     eraserButton.MaxTimer += 10;
                     eraserButton.Timer = eraserButton.MaxTimer;
 
@@ -907,7 +998,7 @@ namespace TheOtherRoles
                 },
                 () => { return Eraser.eraser != null && Eraser.eraser == CachedPlayer.LocalPlayer.PlayerControl && !CachedPlayer.LocalPlayer.Data.IsDead; },
                 () => { return CachedPlayer.LocalPlayer.PlayerControl.CanMove && Eraser.currentTarget != null; },
-                () => { eraserButton.Timer = eraserButton.MaxTimer;},
+                () => { eraserButton.Timer = eraserButton.MaxTimer; },
                 Eraser.getButtonSprite(),
                 new Vector3(-1.8f, -0.06f, 0),
                 __instance,
@@ -915,37 +1006,40 @@ namespace TheOtherRoles
             );
 
             placeJackInTheBoxButton = new CustomButton(
-                () => {
+                () =>
+                {
                     placeJackInTheBoxButton.Timer = placeJackInTheBoxButton.MaxTimer;
 
                     var pos = CachedPlayer.LocalPlayer.transform.position;
                     byte[] buff = new byte[sizeof(float) * 2];
-                    Buffer.BlockCopy(BitConverter.GetBytes(pos.x), 0, buff, 0*sizeof(float), sizeof(float));
-                    Buffer.BlockCopy(BitConverter.GetBytes(pos.y), 0, buff, 1*sizeof(float), sizeof(float));
+                    Buffer.BlockCopy(BitConverter.GetBytes(pos.x), 0, buff, 0 * sizeof(float), sizeof(float));
+                    Buffer.BlockCopy(BitConverter.GetBytes(pos.y), 0, buff, 1 * sizeof(float), sizeof(float));
 
                     MessageWriter writer = AmongUsClient.Instance.StartRpc(CachedPlayer.LocalPlayer.PlayerControl.NetId, (byte)CustomRPC.PlaceJackInTheBox, Hazel.SendOption.Reliable);
                     writer.WriteBytesAndSize(buff);
                     writer.EndMessage();
-                    RPCProcedure.placeJackInTheBox(buff); 
+                    RPCProcedure.placeJackInTheBox(buff);
                 },
                 () => { return Trickster.trickster != null && Trickster.trickster == CachedPlayer.LocalPlayer.PlayerControl && !CachedPlayer.LocalPlayer.Data.IsDead && !JackInTheBox.hasJackInTheBoxLimitReached(); },
                 () => { return CachedPlayer.LocalPlayer.PlayerControl.CanMove && !JackInTheBox.hasJackInTheBoxLimitReached(); },
-                () => { placeJackInTheBoxButton.Timer = placeJackInTheBoxButton.MaxTimer;},
+                () => { placeJackInTheBoxButton.Timer = placeJackInTheBoxButton.MaxTimer; },
                 Trickster.getPlaceBoxButtonSprite(),
                 new Vector3(-1.8f, -0.06f, 0),
                 __instance,
                 KeyCode.F
             );
-            
+
             lightsOutButton = new CustomButton(
-                () => {
+                () =>
+                {
                     MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(CachedPlayer.LocalPlayer.PlayerControl.NetId, (byte)CustomRPC.LightsOut, Hazel.SendOption.Reliable, -1);
                     AmongUsClient.Instance.FinishRpcImmediately(writer);
-                    RPCProcedure.lightsOut(); 
+                    RPCProcedure.lightsOut();
                 },
                 () => { return Trickster.trickster != null && Trickster.trickster == CachedPlayer.LocalPlayer.PlayerControl && !CachedPlayer.LocalPlayer.Data.IsDead && JackInTheBox.hasJackInTheBoxLimitReached() && JackInTheBox.boxesConvertedToVents; },
                 () => { return CachedPlayer.LocalPlayer.PlayerControl.CanMove && JackInTheBox.hasJackInTheBoxLimitReached() && JackInTheBox.boxesConvertedToVents; },
-                () => { 
+                () =>
+                {
                     lightsOutButton.Timer = lightsOutButton.MaxTimer;
                     lightsOutButton.isEffectActive = false;
                     lightsOutButton.actionButton.graphic.color = Palette.EnabledColor;
@@ -961,8 +1055,10 @@ namespace TheOtherRoles
 
             // Cleaner Clean
             cleanerCleanButton = new CustomButton(
-                () => {
-                    foreach (Collider2D collider2D in Physics2D.OverlapCircleAll(CachedPlayer.LocalPlayer.PlayerControl.GetTruePosition(), CachedPlayer.LocalPlayer.PlayerControl.MaxReportDistance, Constants.PlayersOnlyMask)) {
+                () =>
+                {
+                    foreach (Collider2D collider2D in Physics2D.OverlapCircleAll(CachedPlayer.LocalPlayer.PlayerControl.GetTruePosition(), CachedPlayer.LocalPlayer.PlayerControl.MaxReportDistance, Constants.PlayersOnlyMask))
+                    {
                         if (collider2D.tag == "DeadBody")
                         {
                             DeadBody component = collider2D.GetComponent<DeadBody>();
@@ -973,7 +1069,7 @@ namespace TheOtherRoles
                                 if (Vector2.Distance(truePosition2, truePosition) <= CachedPlayer.LocalPlayer.PlayerControl.MaxReportDistance && CachedPlayer.LocalPlayer.PlayerControl.CanMove && !PhysicsHelpers.AnythingBetween(truePosition, truePosition2, Constants.ShipAndObjectsMask, false))
                                 {
                                     GameData.PlayerInfo playerInfo = GameData.Instance.GetPlayerById(component.ParentId);
-                                    
+
                                     MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(CachedPlayer.LocalPlayer.PlayerControl.NetId, (byte)CustomRPC.CleanBody, Hazel.SendOption.Reliable, -1);
                                     writer.Write(playerInfo.PlayerId);
                                     AmongUsClient.Instance.FinishRpcImmediately(writer);
@@ -997,37 +1093,45 @@ namespace TheOtherRoles
 
             // Warlock curse
             warlockCurseButton = new CustomButton(
-                () => {
-                    if (Warlock.curseVictim == null) {
+                () =>
+                {
+                    if (Warlock.curseVictim == null)
+                    {
                         // Apply Curse
                         Warlock.curseVictim = Warlock.currentTarget;
                         warlockCurseButton.Sprite = Warlock.getCurseKillButtonSprite();
                         warlockCurseButton.Timer = 1f;
-                    } else if (Warlock.curseVictim != null && Warlock.curseVictimTarget != null) {
+                    }
+                    else if (Warlock.curseVictim != null && Warlock.curseVictimTarget != null)
+                    {
                         MurderAttemptResult murder = Helpers.checkMuderAttemptAndKill(Warlock.warlock, Warlock.curseVictimTarget, showAnimation: false);
-                        if (murder == MurderAttemptResult.SuppressKill) return; 
+                        if (murder == MurderAttemptResult.SuppressKill) return;
 
                         // If blanked or killed
-                        if(Warlock.rootTime > 0) {
+                        if (Warlock.rootTime > 0)
+                        {
                             CachedPlayer.LocalPlayer.PlayerControl.moveable = false;
                             CachedPlayer.LocalPlayer.NetTransform.Halt(); // Stop current movement so the warlock is not just running straight into the next object
-                            FastDestroyableSingleton<HudManager>.Instance.StartCoroutine(Effects.Lerp(Warlock.rootTime, new Action<float>((p) => { // Delayed action
-                                if (p == 1f) {
+                            FastDestroyableSingleton<HudManager>.Instance.StartCoroutine(Effects.Lerp(Warlock.rootTime, new Action<float>((p) =>
+                            { // Delayed action
+                                if (p == 1f)
+                                {
                                     CachedPlayer.LocalPlayer.PlayerControl.moveable = true;
                                 }
                             })));
                         }
-                        
+
                         Warlock.curseVictim = null;
                         Warlock.curseVictimTarget = null;
                         warlockCurseButton.Sprite = Warlock.getCurseButtonSprite();
                         Warlock.warlock.killTimer = warlockCurseButton.Timer = warlockCurseButton.MaxTimer;
-                        
+
                     }
                 },
                 () => { return Warlock.warlock != null && Warlock.warlock == CachedPlayer.LocalPlayer.PlayerControl && !CachedPlayer.LocalPlayer.Data.IsDead; },
                 () => { return ((Warlock.curseVictim == null && Warlock.currentTarget != null) || (Warlock.curseVictim != null && Warlock.curseVictimTarget != null)) && CachedPlayer.LocalPlayer.PlayerControl.CanMove; },
-                () => { 
+                () =>
+                {
                     warlockCurseButton.Timer = warlockCurseButton.MaxTimer;
                     warlockCurseButton.Sprite = Warlock.getCurseButtonSprite();
                     Warlock.curseVictim = null;
@@ -1041,30 +1145,35 @@ namespace TheOtherRoles
 
             // Security Guard button
             securityGuardButton = new CustomButton(
-                () => {
-                    if (SecurityGuard.ventTarget != null) { // Seal vent
+                () =>
+                {
+                    if (SecurityGuard.ventTarget != null)
+                    { // Seal vent
                         MessageWriter writer = AmongUsClient.Instance.StartRpc(CachedPlayer.LocalPlayer.PlayerControl.NetId, (byte)CustomRPC.SealVent, Hazel.SendOption.Reliable);
                         writer.WritePacked(SecurityGuard.ventTarget.Id);
                         writer.EndMessage();
                         RPCProcedure.sealVent(SecurityGuard.ventTarget.Id);
                         SecurityGuard.ventTarget = null;
-                        
-                    } else if (PlayerControl.GameOptions.MapId != 1 && !SubmergedCompatibility.IsSubmerged) { // Place camera if there's no vent and it's not MiraHQ or Submerged
+
+                    }
+                    else if (PlayerControl.GameOptions.MapId != 1 && !SubmergedCompatibility.IsSubmerged)
+                    { // Place camera if there's no vent and it's not MiraHQ or Submerged
                         var pos = CachedPlayer.LocalPlayer.transform.position;
                         byte[] buff = new byte[sizeof(float) * 2];
-                        Buffer.BlockCopy(BitConverter.GetBytes(pos.x), 0, buff, 0*sizeof(float), sizeof(float));
-                        Buffer.BlockCopy(BitConverter.GetBytes(pos.y), 0, buff, 1*sizeof(float), sizeof(float));
+                        Buffer.BlockCopy(BitConverter.GetBytes(pos.x), 0, buff, 0 * sizeof(float), sizeof(float));
+                        Buffer.BlockCopy(BitConverter.GetBytes(pos.y), 0, buff, 1 * sizeof(float), sizeof(float));
 
                         MessageWriter writer = AmongUsClient.Instance.StartRpc(CachedPlayer.LocalPlayer.PlayerControl.NetId, (byte)CustomRPC.PlaceCamera, Hazel.SendOption.Reliable);
                         writer.WriteBytesAndSize(buff);
                         writer.EndMessage();
-                        RPCProcedure.placeCamera(buff); 
+                        RPCProcedure.placeCamera(buff);
                     }
                     securityGuardButton.Timer = securityGuardButton.MaxTimer;
                 },
                 () => { return SecurityGuard.securityGuard != null && SecurityGuard.securityGuard == CachedPlayer.LocalPlayer.PlayerControl && !CachedPlayer.LocalPlayer.Data.IsDead && SecurityGuard.remainingScrews >= Mathf.Min(SecurityGuard.ventPrice, SecurityGuard.camPrice); },
-                () => {
-                    securityGuardButton.actionButton.graphic.sprite = (SecurityGuard.ventTarget == null && PlayerControl.GameOptions.MapId != 1 && !SubmergedCompatibility.IsSubmerged) ? SecurityGuard.getPlaceCameraButtonSprite() : SecurityGuard.getCloseVentButtonSprite(); 
+                () =>
+                {
+                    securityGuardButton.actionButton.graphic.sprite = (SecurityGuard.ventTarget == null && PlayerControl.GameOptions.MapId != 1 && !SubmergedCompatibility.IsSubmerged) ? SecurityGuard.getPlaceCameraButtonSprite() : SecurityGuard.getCloseVentButtonSprite();
                     if (securityGuardButtonScrewsText != null) securityGuardButtonScrewsText.text = $"{SecurityGuard.remainingScrews}/{SecurityGuard.totalScrews}";
 
                     if (SecurityGuard.ventTarget != null)
@@ -1077,7 +1186,7 @@ namespace TheOtherRoles
                 __instance,
                 KeyCode.F
             );
-            
+
             // Security Guard button screws counter
             securityGuardButtonScrewsText = GameObject.Instantiate(securityGuardButton.actionButton.cooldownTimerText, securityGuardButton.actionButton.cooldownTimerText.transform.parent);
             securityGuardButtonScrewsText.text = "";
@@ -1086,9 +1195,12 @@ namespace TheOtherRoles
             securityGuardButtonScrewsText.transform.localPosition += new Vector3(-0.05f, 0.7f, 0);
 
             securityGuardCamButton = new CustomButton(
-                () => {
-                    if (PlayerControl.GameOptions.MapId != 1) {
-                        if (SecurityGuard.minigame == null) {
+                () =>
+                {
+                    if (PlayerControl.GameOptions.MapId != 1)
+                    {
+                        if (SecurityGuard.minigame == null)
+                        {
                             byte mapId = PlayerControl.GameOptions.MapId;
                             var e = UnityEngine.Object.FindObjectsOfType<SystemConsole>().FirstOrDefault(x => x.gameObject.name.Contains("Surv_Panel"));
                             if (mapId == 0 || mapId == 3) e = UnityEngine.Object.FindObjectsOfType<SystemConsole>().FirstOrDefault(x => x.gameObject.name.Contains("SurvConsole"));
@@ -1099,8 +1211,11 @@ namespace TheOtherRoles
                         SecurityGuard.minigame.transform.SetParent(Camera.main.transform, false);
                         SecurityGuard.minigame.transform.localPosition = new Vector3(0.0f, 0.0f, -50f);
                         SecurityGuard.minigame.Begin(null);
-                    } else {
-                        if (SecurityGuard.minigame == null) {
+                    }
+                    else
+                    {
+                        if (SecurityGuard.minigame == null)
+                        {
                             var e = UnityEngine.Object.FindObjectsOfType<SystemConsole>().FirstOrDefault(x => x.gameObject.name.Contains("SurvLogConsole"));
                             if (e == null || Camera.main == null) return;
                             SecurityGuard.minigame = UnityEngine.Object.Instantiate(e.MinigamePrefab, Camera.main.transform, false);
@@ -1114,15 +1229,20 @@ namespace TheOtherRoles
                     if (SecurityGuard.cantMove) CachedPlayer.LocalPlayer.PlayerControl.moveable = false;
                     CachedPlayer.LocalPlayer.NetTransform.Halt(); // Stop current movement 
                 },
-                () => { return SecurityGuard.securityGuard != null && SecurityGuard.securityGuard == CachedPlayer.LocalPlayer.PlayerControl && !CachedPlayer.LocalPlayer.Data.IsDead && SecurityGuard.remainingScrews < Mathf.Min(SecurityGuard.ventPrice, SecurityGuard.camPrice)
-                               && !SubmergedCompatibility.IsSubmerged; },
-                () => {
+                () =>
+                {
+                    return SecurityGuard.securityGuard != null && SecurityGuard.securityGuard == CachedPlayer.LocalPlayer.PlayerControl && !CachedPlayer.LocalPlayer.Data.IsDead && SecurityGuard.remainingScrews < Mathf.Min(SecurityGuard.ventPrice, SecurityGuard.camPrice)
+                               && !SubmergedCompatibility.IsSubmerged;
+                },
+                () =>
+                {
                     if (securityGuardChargesText != null) securityGuardChargesText.text = $"{SecurityGuard.charges} / {SecurityGuard.maxCharges}";
                     securityGuardCamButton.actionButton.graphic.sprite = PlayerControl.GameOptions.MapId == 1 ? SecurityGuard.getLogSprite() : SecurityGuard.getCamSprite();
                     securityGuardCamButton.actionButton.OverrideText(PlayerControl.GameOptions.MapId == 1 ? "DOORLOG" : "SECURITY");
                     return CachedPlayer.LocalPlayer.PlayerControl.CanMove && SecurityGuard.charges > 0;
                 },
-                () => {
+                () =>
+                {
                     securityGuardCamButton.Timer = securityGuardCamButton.MaxTimer;
                     securityGuardCamButton.isEffectActive = false;
                     securityGuardCamButton.actionButton.cooldownTimerText.color = Palette.EnabledColor;
@@ -1133,9 +1253,11 @@ namespace TheOtherRoles
                 KeyCode.Q,
                 true,
                 0f,
-                () => {
+                () =>
+                {
                     securityGuardCamButton.Timer = securityGuardCamButton.MaxTimer;
-                    if (Minigame.Instance) {
+                    if (Minigame.Instance)
+                    {
                         SecurityGuard.minigame.ForceClose();
                     }
                     CachedPlayer.LocalPlayer.PlayerControl.moveable = true;
@@ -1153,24 +1275,30 @@ namespace TheOtherRoles
 
             // Arsonist button
             arsonistButton = new CustomButton(
-                () => {
+                () =>
+                {
                     bool dousedEveryoneAlive = Arsonist.dousedEveryoneAlive();
-                    if (dousedEveryoneAlive) {
+                    if (dousedEveryoneAlive)
+                    {
                         MessageWriter winWriter = AmongUsClient.Instance.StartRpcImmediately(CachedPlayer.LocalPlayer.PlayerControl.NetId, (byte)CustomRPC.ArsonistWin, Hazel.SendOption.Reliable, -1);
                         AmongUsClient.Instance.FinishRpcImmediately(winWriter);
                         RPCProcedure.arsonistWin();
                         arsonistButton.HasEffect = false;
-                    } else if (Arsonist.currentTarget != null) {
+                    }
+                    else if (Arsonist.currentTarget != null)
+                    {
                         Arsonist.douseTarget = Arsonist.currentTarget;
-                        arsonistButton.HasEffect = true;              
+                        arsonistButton.HasEffect = true;
                     }
                 },
                 () => { return Arsonist.arsonist != null && Arsonist.arsonist == CachedPlayer.LocalPlayer.PlayerControl && !CachedPlayer.LocalPlayer.Data.IsDead; },
-                () => {
+                () =>
+                {
                     bool dousedEveryoneAlive = Arsonist.dousedEveryoneAlive();
                     if (dousedEveryoneAlive) arsonistButton.actionButton.graphic.sprite = Arsonist.getIgniteSprite();
-                    
-                    if (arsonistButton.isEffectActive && Arsonist.douseTarget != Arsonist.currentTarget) {
+
+                    if (arsonistButton.isEffectActive && Arsonist.douseTarget != Arsonist.currentTarget)
+                    {
                         Arsonist.douseTarget = null;
                         arsonistButton.Timer = 0f;
                         arsonistButton.isEffectActive = false;
@@ -1178,7 +1306,8 @@ namespace TheOtherRoles
 
                     return CachedPlayer.LocalPlayer.PlayerControl.CanMove && (dousedEveryoneAlive || Arsonist.currentTarget != null);
                 },
-                () => {
+                () =>
+                {
                     arsonistButton.Timer = arsonistButton.MaxTimer;
                     arsonistButton.isEffectActive = false;
                     Arsonist.douseTarget = null;
@@ -1189,13 +1318,16 @@ namespace TheOtherRoles
                 KeyCode.F,
                 true,
                 Arsonist.duration,
-                () => {
+                () =>
+                {
                     if (Arsonist.douseTarget != null) Arsonist.dousedPlayers.Add(Arsonist.douseTarget);
                     Arsonist.douseTarget = null;
                     arsonistButton.Timer = Arsonist.dousedEveryoneAlive() ? 0 : arsonistButton.MaxTimer;
 
-                    foreach (PlayerControl p in Arsonist.dousedPlayers) {
-                        if (MapOptions.playerIcons.ContainsKey(p.PlayerId)) {
+                    foreach (PlayerControl p in Arsonist.dousedPlayers)
+                    {
+                        if (MapOptions.playerIcons.ContainsKey(p.PlayerId))
+                        {
                             MapOptions.playerIcons[p.PlayerId].setSemiTransparent(false);
                         }
                     }
@@ -1204,14 +1336,19 @@ namespace TheOtherRoles
 
             // Vulture Eat
             vultureEatButton = new CustomButton(
-                () => {
-                    foreach (Collider2D collider2D in Physics2D.OverlapCircleAll(CachedPlayer.LocalPlayer.PlayerControl.GetTruePosition(), CachedPlayer.LocalPlayer.PlayerControl.MaxReportDistance, Constants.PlayersOnlyMask)) {
-                        if (collider2D.tag == "DeadBody") {
+                () =>
+                {
+                    foreach (Collider2D collider2D in Physics2D.OverlapCircleAll(CachedPlayer.LocalPlayer.PlayerControl.GetTruePosition(), CachedPlayer.LocalPlayer.PlayerControl.MaxReportDistance, Constants.PlayersOnlyMask))
+                    {
+                        if (collider2D.tag == "DeadBody")
+                        {
                             DeadBody component = collider2D.GetComponent<DeadBody>();
-                            if (component && !component.Reported) {
+                            if (component && !component.Reported)
+                            {
                                 Vector2 truePosition = CachedPlayer.LocalPlayer.PlayerControl.GetTruePosition();
                                 Vector2 truePosition2 = component.TruePosition;
-                                if (Vector2.Distance(truePosition2, truePosition) <= CachedPlayer.LocalPlayer.PlayerControl.MaxReportDistance && CachedPlayer.LocalPlayer.PlayerControl.CanMove && !PhysicsHelpers.AnythingBetween(truePosition, truePosition2, Constants.ShipAndObjectsMask, false)) {
+                                if (Vector2.Distance(truePosition2, truePosition) <= CachedPlayer.LocalPlayer.PlayerControl.MaxReportDistance && CachedPlayer.LocalPlayer.PlayerControl.CanMove && !PhysicsHelpers.AnythingBetween(truePosition, truePosition2, Constants.ShipAndObjectsMask, false))
+                                {
                                     GameData.PlayerInfo playerInfo = GameData.Instance.GetPlayerById(component.ParentId);
 
                                     MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(CachedPlayer.LocalPlayer.PlayerControl.NetId, (byte)CustomRPC.CleanBody, Hazel.SendOption.Reliable, -1);
@@ -1226,7 +1363,8 @@ namespace TheOtherRoles
                             }
                         }
                     }
-                    if (Vulture.eatenBodies == Vulture.vultureNumberToWin) {
+                    if (Vulture.eatenBodies == Vulture.vultureNumberToWin)
+                    {
                         MessageWriter winWriter = AmongUsClient.Instance.StartRpcImmediately(CachedPlayer.LocalPlayer.PlayerControl.NetId, (byte)CustomRPC.VultureWin, Hazel.SendOption.Reliable, -1);
                         AmongUsClient.Instance.FinishRpcImmediately(winWriter);
                         RPCProcedure.vultureWin();
@@ -1234,7 +1372,11 @@ namespace TheOtherRoles
                     }
                 },
                 () => { return Vulture.vulture != null && Vulture.vulture == CachedPlayer.LocalPlayer.PlayerControl && !CachedPlayer.LocalPlayer.Data.IsDead; },
-                () => { return __instance.ReportButton.graphic.color == Palette.EnabledColor && CachedPlayer.LocalPlayer.PlayerControl.CanMove; },
+                () =>
+                {
+                    if (vultureEatText != null) vultureEatText.text = $"{Vulture.eatenBodies} / {Vulture.vultureNumberToWin}";
+                    return __instance.ReportButton.graphic.color == Palette.EnabledColor && CachedPlayer.LocalPlayer.PlayerControl.CanMove;
+                },
                 () => { vultureEatButton.Timer = vultureEatButton.MaxTimer; },
                 Vulture.getButtonSprite(),
                 new Vector3(-1.8f, -0.06f, 0),
@@ -1242,24 +1384,37 @@ namespace TheOtherRoles
                 KeyCode.F
             );
 
+            // Vulture Eat Text Box
+            vultureEatText = GameObject.Instantiate(vultureEatButton.actionButton.cooldownTimerText, vultureEatButton.actionButton.cooldownTimerText.transform.parent);
+            vultureEatText.text = "";
+            vultureEatText.enableWordWrapping = false;
+            vultureEatText.transform.localScale = Vector3.one * 0.5f;
+            vultureEatText.transform.localPosition += new Vector3(0.05f, -0.7f, 0);
+
+
             // Medium button
             mediumButton = new CustomButton(
-                () => {
-                    if (Medium.target != null) {
+                () =>
+                {
+                    if (Medium.target != null)
+                    {
                         Medium.soulTarget = Medium.target;
                         mediumButton.HasEffect = true;
                     }
                 },
                 () => { return Medium.medium != null && Medium.medium == CachedPlayer.LocalPlayer.PlayerControl && !CachedPlayer.LocalPlayer.Data.IsDead; },
-                () => {
-                    if (mediumButton.isEffectActive && Medium.target != Medium.soulTarget) {
+                () =>
+                {
+                    if (mediumButton.isEffectActive && Medium.target != Medium.soulTarget)
+                    {
                         Medium.soulTarget = null;
                         mediumButton.Timer = 0f;
                         mediumButton.isEffectActive = false;
                     }
                     return Medium.target != null && CachedPlayer.LocalPlayer.PlayerControl.CanMove;
                 },
-                () => {
+                () =>
+                {
                     mediumButton.Timer = mediumButton.MaxTimer;
                     mediumButton.isEffectActive = false;
                     Medium.soulTarget = null;
@@ -1270,7 +1425,8 @@ namespace TheOtherRoles
                 KeyCode.F,
                 true,
                 Medium.duration,
-                () => {
+                () =>
+                {
                     mediumButton.Timer = mediumButton.MaxTimer;
                     if (Medium.target == null || Medium.target.player == null) return;
                     string msg = "";
@@ -1289,28 +1445,35 @@ namespace TheOtherRoles
                     FastDestroyableSingleton<HudManager>.Instance.Chat.AddChat(CachedPlayer.LocalPlayer.PlayerControl, $"{msg}");
 
                     // Remove soul
-                    if (Medium.oneTimeUse) {
+                    if (Medium.oneTimeUse)
+                    {
                         float closestDistance = float.MaxValue;
                         SpriteRenderer target = null;
 
-                        foreach ((DeadPlayer db, Vector3 ps) in Medium.deadBodies) {
-                            if (db == Medium.target) {
+                        foreach ((DeadPlayer db, Vector3 ps) in Medium.deadBodies)
+                        {
+                            if (db == Medium.target)
+                            {
                                 Tuple<DeadPlayer, Vector3> deadBody = Tuple.Create(db, ps);
                                 Medium.deadBodies.Remove(deadBody);
                                 break;
                             }
 
                         }
-                        foreach (SpriteRenderer rend in Medium.souls) {
+                        foreach (SpriteRenderer rend in Medium.souls)
+                        {
                             float distance = Vector2.Distance(rend.transform.position, CachedPlayer.LocalPlayer.PlayerControl.GetTruePosition());
-                            if (distance < closestDistance) {
+                            if (distance < closestDistance)
+                            {
                                 closestDistance = distance;
                                 target = rend;
                             }
                         }
 
-                        FastDestroyableSingleton<HudManager>.Instance.StartCoroutine(Effects.Lerp(5f, new Action<float>((p) => {
-                            if (target != null) {
+                        FastDestroyableSingleton<HudManager>.Instance.StartCoroutine(Effects.Lerp(5f, new Action<float>((p) =>
+                        {
+                            if (target != null)
+                            {
                                 var tmp = target.color;
                                 tmp.a = Mathf.Clamp01(1 - p);
                                 target.color = tmp;
@@ -1325,8 +1488,10 @@ namespace TheOtherRoles
 
             // Pursuer button
             pursuerButton = new CustomButton(
-                () => {
-                    if (Pursuer.target != null) {
+                () =>
+                {
+                    if (Pursuer.target != null)
+                    {
                         MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(CachedPlayer.LocalPlayer.PlayerControl.NetId, (byte)CustomRPC.SetBlanked, Hazel.SendOption.Reliable, -1);
                         writer.Write(Pursuer.target.PlayerId);
                         writer.Write(Byte.MaxValue);
@@ -1341,7 +1506,8 @@ namespace TheOtherRoles
 
                 },
                 () => { return Pursuer.pursuer != null && Pursuer.pursuer == CachedPlayer.LocalPlayer.PlayerControl && !CachedPlayer.LocalPlayer.Data.IsDead && Pursuer.blanks < Pursuer.blanksNumber; },
-                () => {
+                () =>
+                {
                     if (pursuerButtonBlanksText != null) pursuerButtonBlanksText.text = $"{Pursuer.blanksNumber - Pursuer.blanks}";
 
                     return Pursuer.blanksNumber > Pursuer.blanks && CachedPlayer.LocalPlayer.PlayerControl.CanMove && Pursuer.target != null;
@@ -1363,21 +1529,26 @@ namespace TheOtherRoles
 
             // Witch Spell button
             witchSpellButton = new CustomButton(
-                () => {
-                    if (Witch.currentTarget != null) {
+                () =>
+                {
+                    if (Witch.currentTarget != null)
+                    {
                         Witch.spellCastingTarget = Witch.currentTarget;
                     }
                 },
                 () => { return Witch.witch != null && Witch.witch == CachedPlayer.LocalPlayer.PlayerControl && !CachedPlayer.LocalPlayer.Data.IsDead; },
-                () => {
-                    if (witchSpellButton.isEffectActive && Witch.spellCastingTarget != Witch.currentTarget) {
+                () =>
+                {
+                    if (witchSpellButton.isEffectActive && Witch.spellCastingTarget != Witch.currentTarget)
+                    {
                         Witch.spellCastingTarget = null;
                         witchSpellButton.Timer = 0f;
                         witchSpellButton.isEffectActive = false;
                     }
                     return CachedPlayer.LocalPlayer.PlayerControl.CanMove && Witch.currentTarget != null;
                 },
-                () => {
+                () =>
+                {
                     witchSpellButton.Timer = witchSpellButton.MaxTimer;
                     witchSpellButton.isEffectActive = false;
                     Witch.spellCastingTarget = null;
@@ -1388,25 +1559,31 @@ namespace TheOtherRoles
                 KeyCode.F,
                 true,
                 Witch.spellCastingDuration,
-                () => {
+                () =>
+                {
                     if (Witch.spellCastingTarget == null) return;
                     MurderAttemptResult attempt = Helpers.checkMuderAttempt(Witch.witch, Witch.spellCastingTarget);
-                    if (attempt == MurderAttemptResult.PerformKill) {
+                    if (attempt == MurderAttemptResult.PerformKill)
+                    {
                         MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(CachedPlayer.LocalPlayer.PlayerControl.NetId, (byte)CustomRPC.SetFutureSpelled, Hazel.SendOption.Reliable, -1);
                         writer.Write(Witch.currentTarget.PlayerId);
                         AmongUsClient.Instance.FinishRpcImmediately(writer);
                         RPCProcedure.setFutureSpelled(Witch.currentTarget.PlayerId);
                     }
-                    if (attempt == MurderAttemptResult.BlankKill || attempt == MurderAttemptResult.PerformKill) {
+                    if (attempt == MurderAttemptResult.BlankKill || attempt == MurderAttemptResult.PerformKill)
+                    {
                         Witch.currentCooldownAddition += Witch.cooldownAddition;
                         witchSpellButton.MaxTimer = Witch.cooldown + Witch.currentCooldownAddition;
                         Patches.PlayerControlFixedUpdatePatch.miniCooldownUpdate();  // Modifies the MaxTimer if the witch is the mini
                         witchSpellButton.Timer = witchSpellButton.MaxTimer;
-                        if (Witch.triggerBothCooldowns) {
+                        if (Witch.triggerBothCooldowns)
+                        {
                             float multiplier = (Mini.mini != null && CachedPlayer.LocalPlayer.PlayerControl == Mini.mini) ? (Mini.isGrownUp() ? 0.66f : 2f) : 1f;
                             Witch.witch.killTimer = PlayerControl.GameOptions.KillCooldown * multiplier;
                         }
-                    } else {
+                    }
+                    else
+                    {
                         witchSpellButton.Timer = 0f;
                     }
                     Witch.spellCastingTarget = null;
@@ -1415,11 +1592,14 @@ namespace TheOtherRoles
 
             // Ninja mark and assassinate button 
             ninjaButton = new CustomButton(
-                () => {
-                    if (Ninja.ninjaMarked != null) {
+                () =>
+                {
+                    if (Ninja.ninjaMarked != null)
+                    {
                         // Murder attempt with teleport
                         MurderAttemptResult attempt = Helpers.checkMuderAttempt(Ninja.ninja, Ninja.ninjaMarked);
-                        if (attempt == MurderAttemptResult.PerformKill) {
+                        if (attempt == MurderAttemptResult.PerformKill)
+                        {
                             // Create first trace before killing
                             var pos = CachedPlayer.LocalPlayer.transform.position;
                             byte[] buff = new byte[sizeof(float) * 2];
@@ -1443,8 +1623,9 @@ namespace TheOtherRoles
                             writer2.Write(Ninja.ninjaMarked.PlayerId);
                             writer2.Write(byte.MaxValue);
                             AmongUsClient.Instance.FinishRpcImmediately(writer2);
-                            if (SubmergedCompatibility.IsSubmerged) {
-                                    SubmergedCompatibility.ChangeFloor(Ninja.ninjaMarked.transform.localPosition.y > -7);
+                            if (SubmergedCompatibility.IsSubmerged)
+                            {
+                                SubmergedCompatibility.ChangeFloor(Ninja.ninjaMarked.transform.localPosition.y > -7);
                             }
                             RPCProcedure.uncheckedMurderPlayer(CachedPlayer.LocalPlayer.PlayerId, Ninja.ninjaMarked.PlayerId, byte.MaxValue);
 
@@ -1460,40 +1641,47 @@ namespace TheOtherRoles
                             RPCProcedure.placeNinjaTrace(buff);
                         }
 
-                        if (attempt == MurderAttemptResult.BlankKill || attempt == MurderAttemptResult.PerformKill) {
+                        if (attempt == MurderAttemptResult.BlankKill || attempt == MurderAttemptResult.PerformKill)
+                        {
                             ninjaButton.Timer = ninjaButton.MaxTimer;
                             Ninja.ninja.killTimer = PlayerControl.GameOptions.KillCooldown;
-                        } else if (attempt == MurderAttemptResult.SuppressKill) {
+                        }
+                        else if (attempt == MurderAttemptResult.SuppressKill)
+                        {
                             ninjaButton.Timer = 0f;
                         }
                         Ninja.ninjaMarked = null;
                         return;
-                    } 
-                    if (Ninja.currentTarget != null) {
+                    }
+                    if (Ninja.currentTarget != null)
+                    {
                         Ninja.ninjaMarked = Ninja.currentTarget;
                         ninjaButton.Timer = 5f;
                     }
                 },
                 () => { return Ninja.ninja != null && Ninja.ninja == CachedPlayer.LocalPlayer.PlayerControl && !CachedPlayer.LocalPlayer.Data.IsDead; },
-                () => {  // CouldUse
-                    ninjaButton.Sprite = Ninja.ninjaMarked != null ? Ninja.getKillButtonSprite() : Ninja.getMarkButtonSprite(); 
+                () =>
+                {  // CouldUse
+                    ninjaButton.Sprite = Ninja.ninjaMarked != null ? Ninja.getKillButtonSprite() : Ninja.getMarkButtonSprite();
                     return (Ninja.currentTarget != null || Ninja.ninjaMarked != null) && CachedPlayer.LocalPlayer.PlayerControl.CanMove;
                 },
-                () => {  // on meeting ends
+                () =>
+                {  // on meeting ends
                     ninjaButton.Timer = ninjaButton.MaxTimer;
                     Ninja.ninjaMarked = null;
                 },
                 Ninja.getMarkButtonSprite(),
                 new Vector3(-1.8f, -0.06f, 0),
                 __instance,
-                KeyCode.F                   
+                KeyCode.F
             );
 
             mayorMeetingButton = new CustomButton(
-               () => {
+               () =>
+               {
                    CachedPlayer.LocalPlayer.NetTransform.Halt(); // Stop current movement 
                    Mayor.remoteMeetingsLeft--;
-	               Helpers.handleVampireBiteOnBodyReport(); // Manually call Vampire handling, since the CmdReportDeadBody Prefix won't be called
+                   Helpers.handleVampireBiteOnBodyReport(); // Manually call Vampire handling, since the CmdReportDeadBody Prefix won't be called
                    RPCProcedure.uncheckedCmdReportDeadBody(CachedPlayer.LocalPlayer.PlayerId, Byte.MaxValue);
 
                    MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(CachedPlayer.LocalPlayer.PlayerControl.NetId, (byte)CustomRPC.UncheckedCmdReportDeadBody, Hazel.SendOption.Reliable, -1);
@@ -1502,9 +1690,10 @@ namespace TheOtherRoles
                    AmongUsClient.Instance.FinishRpcImmediately(writer);
                    mayorMeetingButton.Timer = 1f;
                },
-               () => { return Mayor.mayor != null && Mayor.mayor == CachedPlayer.LocalPlayer.PlayerControl && !CachedPlayer.LocalPlayer.Data.IsDead ;},
-               () => {
-                   mayorMeetingButton.actionButton.OverrideText("Emergency ("+ Mayor.remoteMeetingsLeft + ")");
+               () => { return Mayor.mayor != null && Mayor.mayor == CachedPlayer.LocalPlayer.PlayerControl && !CachedPlayer.LocalPlayer.Data.IsDead; },
+               () =>
+               {
+                   mayorMeetingButton.actionButton.OverrideText("Emergency (" + Mayor.remoteMeetingsLeft + ")");
                    bool sabotageActive = false;
                    foreach (PlayerTask task in CachedPlayer.LocalPlayer.PlayerControl.myTasks.GetFastEnumerator())
                        if (task.TaskType == TaskTypes.FixLights || task.TaskType == TaskTypes.RestoreOxy || task.TaskType == TaskTypes.ResetReactor || task.TaskType == TaskTypes.ResetSeismic || task.TaskType == TaskTypes.FixComms || task.TaskType == TaskTypes.StopCharles
@@ -1519,15 +1708,19 @@ namespace TheOtherRoles
                KeyCode.F,
                true,
                0f,
-               () => {},
+               () => { },
                false,
                "Meeting"
            );
 
             zoomOutButton = new CustomButton(
-                () => { Helpers.toggleZoom();
+                () =>
+                {
+                    Helpers.toggleZoom();
                 },
-                () => { if (CachedPlayer.LocalPlayer.PlayerControl == null || !CachedPlayer.LocalPlayer.Data.IsDead || CachedPlayer.LocalPlayer.Data.Role.IsImpostor) return false;
+                () =>
+                {
+                    if (CachedPlayer.LocalPlayer.PlayerControl == null || !CachedPlayer.LocalPlayer.Data.IsDead || CachedPlayer.LocalPlayer.Data.Role.IsImpostor) return false;
                     var (playerCompleted, playerTotal) = TasksHandler.taskInfo(CachedPlayer.LocalPlayer.Data);
                     int numberOfLeftTasks = playerTotal - playerCompleted;
                     return numberOfLeftTasks <= 0;

--- a/TheOtherRoles/CustomOptionHolder.cs
+++ b/TheOtherRoles/CustomOptionHolder.cs
@@ -3,11 +3,13 @@ using UnityEngine;
 using static TheOtherRoles.TheOtherRoles;
 using Types = TheOtherRoles.CustomOption.CustomOptionType;
 
-namespace TheOtherRoles {
-    public class CustomOptionHolder {
-        public static string[] rates = new string[]{"0%", "10%", "20%", "30%", "40%", "50%", "60%", "70%", "80%", "90%", "100%"};
-        public static string[] ratesModifier = new string[]{"1", "2", "3"};
-        public static string[] presets = new string[]{"Preset 1", "Preset 2", "Preset 3", "Preset 4", "Preset 5"};
+namespace TheOtherRoles
+{
+    public class CustomOptionHolder
+    {
+        public static string[] rates = new string[] { "0%", "10%", "20%", "30%", "40%", "50%", "60%", "70%", "80%", "90%", "100%" };
+        public static string[] ratesModifier = new string[] { "1", "2", "3" };
+        public static string[] presets = new string[] { "Preset 1", "Preset 2", "Preset 3", "Preset 4", "Preset 5" };
 
         public static CustomOption presetSelection;
         public static CustomOption activateRoles;
@@ -192,7 +194,7 @@ namespace TheOtherRoles {
 
         public static CustomOption cleanerSpawnRate;
         public static CustomOption cleanerCooldown;
-        
+
         public static CustomOption warlockSpawnRate;
         public static CustomOption warlockCooldown;
         public static CustomOption warlockRootTime;
@@ -209,7 +211,7 @@ namespace TheOtherRoles {
 
         public static CustomOption vultureSpawnRate;
         public static CustomOption vultureCooldown;
-        public static CustomOption vultureNumberToWin;
+        // public static CustomOption vultureNumberToWin;
         public static CustomOption vultureCanUseVents;
         public static CustomOption vultureShowArrows;
 
@@ -248,7 +250,7 @@ namespace TheOtherRoles {
         public static CustomOption modifierSunglasses;
         public static CustomOption modifierSunglassesQuantity;
         public static CustomOption modifierSunglassesVision;
-        
+
         public static CustomOption modifierMini;
         public static CustomOption modifierMiniGrowingUpDuration;
 
@@ -259,7 +261,7 @@ namespace TheOtherRoles {
         public static CustomOption modifierInvert;
         public static CustomOption modifierInvertQuantity;
         public static CustomOption modifierInvertDuration;
-        
+
         public static CustomOption maxNumberOfMeetings;
         public static CustomOption blockSkippingInEmergencyMeetings;
         public static CustomOption noVoteIsSelfVote;
@@ -277,18 +279,21 @@ namespace TheOtherRoles {
 
         internal static Dictionary<byte, byte[]> blockedRolePairings = new Dictionary<byte, byte[]>();
 
-        public static string cs(Color c, string s) {
+        public static string cs(Color c, string s)
+        {
             return string.Format("<color=#{0:X2}{1:X2}{2:X2}{3:X2}>{4}</color>", ToByte(c.r), ToByte(c.g), ToByte(c.b), ToByte(c.a), s);
         }
- 
-        private static byte ToByte(float f) {
+
+        private static byte ToByte(float f)
+        {
             f = Mathf.Clamp01(f);
             return (byte)(f * 255);
         }
 
-        public static void Load() {
-            
-            
+        public static void Load()
+        {
+
+
             // Role Options
             presetSelection = CustomOption.Create(0, Types.General, cs(new Color(204f / 255f, 204f / 255f, 0, 1f), "Preset"), presets, null, true);
             activateRoles = CustomOption.Create(1, Types.General, cs(new Color(204f / 255f, 204f / 255f, 0, 1f), "Enable Mod Roles And Block Vanilla Roles"), true, null, true);
@@ -336,7 +341,7 @@ namespace TheOtherRoles {
             warlockRootTime = CustomOption.Create(272, Types.Impostor, "Warlock Root Time", 5f, 0f, 15f, 1f, warlockSpawnRate);
 
             bountyHunterSpawnRate = CustomOption.Create(320, Types.Impostor, cs(BountyHunter.color, "Bounty Hunter"), rates, null, true);
-            bountyHunterBountyDuration = CustomOption.Create(321, Types.Impostor, "Duration After Which Bounty Changes",  60f, 10f, 180f, 10f, bountyHunterSpawnRate);
+            bountyHunterBountyDuration = CustomOption.Create(321, Types.Impostor, "Duration After Which Bounty Changes", 60f, 10f, 180f, 10f, bountyHunterSpawnRate);
             bountyHunterReducedCooldown = CustomOption.Create(322, Types.Impostor, "Cooldown After Killing Bounty", 2.5f, 0f, 30f, 2.5f, bountyHunterSpawnRate);
             bountyHunterPunishmentTime = CustomOption.Create(323, Types.Impostor, "Additional Cooldown After Killing Others", 20f, 0f, 60f, 2.5f, bountyHunterSpawnRate);
             bountyHunterShowArrow = CustomOption.Create(324, Types.Impostor, "Show Arrow Pointing Towards The Bounty", true, bountyHunterSpawnRate);
@@ -362,8 +367,8 @@ namespace TheOtherRoles {
             guesserNumberOfShots = CustomOption.Create(312, Types.Neutral, "Guesser Number Of Shots", 2f, 1f, 15f, 1f, guesserSpawnRate);
             guesserHasMultipleShotsPerMeeting = CustomOption.Create(313, Types.Neutral, "Guesser Can Shoot Multiple Times Per Meeting", false, guesserSpawnRate);
             guesserShowInfoInGhostChat = CustomOption.Create(314, Types.Neutral, "Guesses Visible In Ghost Chat", true, guesserSpawnRate);
-            guesserKillsThroughShield  = CustomOption.Create(315, Types.Neutral, "Guesses Ignore The Medic Shield", true, guesserSpawnRate);
-            guesserEvilCanKillSpy  = CustomOption.Create(316, Types.Neutral, "Evil Guesser Can Guess The Spy", true, guesserSpawnRate);
+            guesserKillsThroughShield = CustomOption.Create(315, Types.Neutral, "Guesses Ignore The Medic Shield", true, guesserSpawnRate);
+            guesserEvilCanKillSpy = CustomOption.Create(316, Types.Neutral, "Evil Guesser Can Guess The Spy", true, guesserSpawnRate);
             guesserSpawnBothRate = CustomOption.Create(317, Types.Neutral, "Both Guesser Spawn Rate", rates, guesserSpawnRate);
             guesserCantGuessSnitchIfTaksDone = CustomOption.Create(318, Types.Neutral, "Guesser Can't Guess Snitch When Tasks Completed", true, guesserSpawnRate);
 
@@ -389,7 +394,7 @@ namespace TheOtherRoles {
 
             vultureSpawnRate = CustomOption.Create(340, Types.Neutral, cs(Vulture.color, "Vulture"), rates, null, true);
             vultureCooldown = CustomOption.Create(341, Types.Neutral, "Vulture Cooldown", 15f, 10f, 60f, 2.5f, vultureSpawnRate);
-            vultureNumberToWin = CustomOption.Create(342, Types.Neutral, "Number Of Corpses Needed To Be Eaten", 4f, 1f, 10f, 1f, vultureSpawnRate);
+            // vultureNumberToWin = CustomOption.Create(342, Types.Neutral, "Number Of Corpses Needed To Be Eaten", 4f, 1f, 10f, 1f, vultureSpawnRate);
             vultureCanUseVents = CustomOption.Create(343, Types.Neutral, "Vulture Can Use Vents", true, vultureSpawnRate);
             vultureShowArrows = CustomOption.Create(344, Types.Neutral, "Show Arrows Pointing Towards The Corpses", true, vultureSpawnRate);
 
@@ -432,7 +437,7 @@ namespace TheOtherRoles {
             lighterDuration = CustomOption.Create(114, Types.Crewmate, "Lighter Duration", 5f, 2.5f, 60f, 2.5f, lighterSpawnRate);
 
             detectiveSpawnRate = CustomOption.Create(120, Types.Crewmate, cs(Detective.color, "Detective"), rates, null, true);
-            detectiveAnonymousFootprints = CustomOption.Create(121, Types.Crewmate, "Anonymous Footprints", false, detectiveSpawnRate); 
+            detectiveAnonymousFootprints = CustomOption.Create(121, Types.Crewmate, "Anonymous Footprints", false, detectiveSpawnRate);
             detectiveFootprintIntervall = CustomOption.Create(122, Types.Crewmate, "Footprint Intervall", 0.5f, 0.25f, 10f, 0.25f, detectiveSpawnRate);
             detectiveFootprintDuration = CustomOption.Create(123, Types.Crewmate, "Footprint Duration", 5f, 0.25f, 10f, 0.25f, detectiveSpawnRate);
             detectiveReportNameDuration = CustomOption.Create(124, Types.Crewmate, "Time Where Detective Reports Will Have Name", 0, 0, 60, 2.5f, detectiveSpawnRate);
@@ -444,7 +449,7 @@ namespace TheOtherRoles {
             timeMasterShieldDuration = CustomOption.Create(133, Types.Crewmate, "Time Master Shield Duration", 3f, 1f, 20f, 1f, timeMasterSpawnRate);
 
             medicSpawnRate = CustomOption.Create(140, Types.Crewmate, cs(Medic.color, "Medic"), rates, null, true);
-            medicShowShielded = CustomOption.Create(143, Types.Crewmate, "Show Shielded Player", new string[] {"Everyone", "Shielded + Medic", "Medic"}, medicSpawnRate);
+            medicShowShielded = CustomOption.Create(143, Types.Crewmate, "Show Shielded Player", new string[] { "Everyone", "Shielded + Medic", "Medic" }, medicSpawnRate);
             medicShowAttemptToShielded = CustomOption.Create(144, Types.Crewmate, "Shielded Player Sees Murder Attempt", false, medicSpawnRate);
             medicSetOrShowShieldAfterMeeting = CustomOption.Create(145, Types.Crewmate, "Shield Will Be Activated", new string[] { "Instantly", "Instantly, Visible\nAfter Meeting", "After Meeting" }, medicSpawnRate);
 
@@ -459,10 +464,10 @@ namespace TheOtherRoles {
 
 
             seerSpawnRate = CustomOption.Create(160, Types.Crewmate, cs(Seer.color, "Seer"), rates, null, true);
-            seerMode = CustomOption.Create(161, Types.Crewmate, "Seer Mode", new string[]{ "Show Death Flash + Souls", "Show Death Flash", "Show Souls"}, seerSpawnRate);
+            seerMode = CustomOption.Create(161, Types.Crewmate, "Seer Mode", new string[] { "Show Death Flash + Souls", "Show Death Flash", "Show Souls" }, seerSpawnRate);
             seerLimitSoulDuration = CustomOption.Create(163, Types.Crewmate, "Seer Limit Soul Duration", false, seerSpawnRate);
             seerSoulDuration = CustomOption.Create(162, Types.Crewmate, "Seer Soul Duration", 15f, 0f, 120f, 5f, seerLimitSoulDuration);
-        
+
             hackerSpawnRate = CustomOption.Create(170, Types.Crewmate, cs(Hacker.color, "Hacker"), rates, null, true);
             hackerCooldown = CustomOption.Create(171, Types.Crewmate, "Hacker Cooldown", 30f, 5f, 60f, 5f, hackerSpawnRate);
             hackerHackeringDuration = CustomOption.Create(172, Types.Crewmate, "Hacker Duration", 10f, 2.5f, 60f, 2.5f, hackerSpawnRate);
@@ -477,7 +482,7 @@ namespace TheOtherRoles {
             trackerCanTrackCorpses = CustomOption.Create(203, Types.Crewmate, "Tracker Can Track Corpses", true, trackerSpawnRate);
             trackerCorpsesTrackingCooldown = CustomOption.Create(204, Types.Crewmate, "Corpses Tracking Cooldown", 30f, 5f, 120f, 5f, trackerCanTrackCorpses);
             trackerCorpsesTrackingDuration = CustomOption.Create(205, Types.Crewmate, "Corpses Tracking Duration", 5f, 2.5f, 30f, 2.5f, trackerCanTrackCorpses);
-                           
+
             snitchSpawnRate = CustomOption.Create(210, Types.Crewmate, cs(Snitch.color, "Snitch"), rates, null, true);
             snitchLeftTasksForReveal = CustomOption.Create(211, Types.Crewmate, "Task Count Where The Snitch Will Be Revealed", 1f, 0f, 5f, 1f, snitchSpawnRate);
             snitchIncludeTeamJackal = CustomOption.Create(212, Types.Crewmate, "Include Team Jackal", false, snitchSpawnRate);
@@ -561,13 +566,13 @@ namespace TheOtherRoles {
 
             dynamicMapEnableSubmerged = CustomOption.Create(505, Types.General, "Enable Submerged Rotation", true, dynamicMap, false);
 
-            blockedRolePairings.Add((byte)RoleId.Vampire, new [] { (byte)RoleId.Warlock});
-            blockedRolePairings.Add((byte)RoleId.Warlock, new [] { (byte)RoleId.Vampire});
-            blockedRolePairings.Add((byte)RoleId.Spy, new [] { (byte)RoleId.Mini});
-            blockedRolePairings.Add((byte)RoleId.Mini, new [] { (byte)RoleId.Spy});
-            blockedRolePairings.Add((byte)RoleId.Vulture, new [] { (byte)RoleId.Cleaner});
-            blockedRolePairings.Add((byte)RoleId.Cleaner, new [] { (byte)RoleId.Vulture});
-            
+            blockedRolePairings.Add((byte)RoleId.Vampire, new[] { (byte)RoleId.Warlock });
+            blockedRolePairings.Add((byte)RoleId.Warlock, new[] { (byte)RoleId.Vampire });
+            blockedRolePairings.Add((byte)RoleId.Spy, new[] { (byte)RoleId.Mini });
+            blockedRolePairings.Add((byte)RoleId.Mini, new[] { (byte)RoleId.Spy });
+            blockedRolePairings.Add((byte)RoleId.Vulture, new[] { (byte)RoleId.Cleaner });
+            blockedRolePairings.Add((byte)RoleId.Cleaner, new[] { (byte)RoleId.Vulture });
+
         }
     }
 }

--- a/TheOtherRoles/TheOtherRoles.cs
+++ b/TheOtherRoles/TheOtherRoles.cs
@@ -14,7 +14,8 @@ namespace TheOtherRoles
     {
         public static System.Random rnd = new System.Random((int)DateTime.Now.Ticks);
 
-        public static void clearAndReloadRoles() {
+        public static void clearAndReloadRoles()
+        {
             Jester.clearAndReload();
             Mayor.clearAndReload();
             Portalmaker.clearAndReload();
@@ -67,7 +68,8 @@ namespace TheOtherRoles
             Invert.clearAndReload();
         }
 
-        public static class Jester {
+        public static class Jester
+        {
             public static PlayerControl jester;
             public static Color color = new Color32(236, 98, 165, byte.MaxValue);
 
@@ -75,15 +77,17 @@ namespace TheOtherRoles
             public static bool canCallEmergency = true;
             public static bool hasImpostorVision = false;
 
-            public static void clearAndReload() {
+            public static void clearAndReload()
+            {
                 jester = null;
                 triggerJesterWin = false;
                 canCallEmergency = CustomOptionHolder.jesterCanCallEmergency.getBool();
                 hasImpostorVision = CustomOptionHolder.jesterHasImpostorVision.getBool();
             }
         }
-        
-        public static class Portalmaker {
+
+        public static class Portalmaker
+        {
             public static PlayerControl portalmaker;
             public static Color color = new Color32(69, 69, 169, byte.MaxValue);
 
@@ -96,25 +100,29 @@ namespace TheOtherRoles
             private static Sprite usePortalButtonSprite;
             private static Sprite logSprite;
 
-            public static Sprite getPlacePortalButtonSprite() {
+            public static Sprite getPlacePortalButtonSprite()
+            {
                 if (placePortalButtonSprite) return placePortalButtonSprite;
                 placePortalButtonSprite = Helpers.loadSpriteFromResources("TheOtherRoles.Resources.PlacePortalButton.png", 115f);
                 return placePortalButtonSprite;
             }
 
-            public static Sprite getUsePortalButtonSprite() {
+            public static Sprite getUsePortalButtonSprite()
+            {
                 if (usePortalButtonSprite) return usePortalButtonSprite;
                 usePortalButtonSprite = Helpers.loadSpriteFromResources("TheOtherRoles.Resources.UsePortalButton.png", 115f);
                 return usePortalButtonSprite;
             }
 
-            public static Sprite getLogSprite() {
+            public static Sprite getLogSprite()
+            {
                 if (logSprite) return logSprite;
                 logSprite = FastDestroyableSingleton<HudManager>.Instance.UseButton.fastUseSettings[ImageNames.DoorLogsButton].Image;
                 return logSprite;
             }
 
-            public static void clearAndReload() {
+            public static void clearAndReload()
+            {
                 portalmaker = null;
                 cooldown = CustomOptionHolder.portalmakerCooldown.getFloat();
                 usePortalCooldown = CustomOptionHolder.portalmakerUsePortalCooldown.getFloat();
@@ -125,7 +133,8 @@ namespace TheOtherRoles
 
         }
 
-        public static class Mayor {
+        public static class Mayor
+        {
             public static PlayerControl mayor;
             public static Color color = new Color32(32, 77, 66, byte.MaxValue);
             public static Minigame emergency = null;
@@ -143,33 +152,37 @@ namespace TheOtherRoles
                 return emergencySprite;
             }
 
-            public static void clearAndReload() {
+            public static void clearAndReload()
+            {
                 mayor = null;
                 emergency = null;
                 emergencySprite = null;
-		        remoteMeetingsLeft = Mathf.RoundToInt(CustomOptionHolder.mayorMaxRemoteMeetings.getFloat()); 
+                remoteMeetingsLeft = Mathf.RoundToInt(CustomOptionHolder.mayorMaxRemoteMeetings.getFloat());
                 canSeeVoteColors = CustomOptionHolder.mayorCanSeeVoteColors.getBool();
                 tasksNeededToSeeVoteColors = (int)CustomOptionHolder.mayorTasksNeededToSeeVoteColors.getFloat();
                 meetingButton = CustomOptionHolder.mayorMeetingButton.getBool();
             }
         }
 
-        public static class Engineer {
+        public static class Engineer
+        {
             public static PlayerControl engineer;
             public static Color color = new Color32(0, 40, 245, byte.MaxValue);
             private static Sprite buttonSprite;
 
-            public static int remainingFixes = 1;           
+            public static int remainingFixes = 1;
             public static bool highlightForImpostors = true;
-            public static bool highlightForTeamJackal = true; 
+            public static bool highlightForTeamJackal = true;
 
-            public static Sprite getButtonSprite() {
+            public static Sprite getButtonSprite()
+            {
                 if (buttonSprite) return buttonSprite;
                 buttonSprite = Helpers.loadSpriteFromResources("TheOtherRoles.Resources.RepairButton.png", 115f);
                 return buttonSprite;
             }
 
-            public static void clearAndReload() {
+            public static void clearAndReload()
+            {
                 engineer = null;
                 remainingFixes = Mathf.RoundToInt(CustomOptionHolder.engineerNumberOfFixes.getFloat());
                 highlightForImpostors = CustomOptionHolder.engineerHighlightForImpostors.getBool();
@@ -177,45 +190,53 @@ namespace TheOtherRoles
             }
         }
 
-        public static class Godfather {
+        public static class Godfather
+        {
             public static PlayerControl godfather;
             public static Color color = Palette.ImpostorRed;
 
-            public static void clearAndReload() {
+            public static void clearAndReload()
+            {
                 godfather = null;
             }
         }
 
-        public static class Mafioso {
+        public static class Mafioso
+        {
             public static PlayerControl mafioso;
             public static Color color = Palette.ImpostorRed;
 
-            public static void clearAndReload() {
+            public static void clearAndReload()
+            {
                 mafioso = null;
             }
         }
 
 
-        public static class Janitor {
+        public static class Janitor
+        {
             public static PlayerControl janitor;
             public static Color color = Palette.ImpostorRed;
 
             public static float cooldown = 30f;
 
             private static Sprite buttonSprite;
-            public static Sprite getButtonSprite() {
+            public static Sprite getButtonSprite()
+            {
                 if (buttonSprite) return buttonSprite;
                 buttonSprite = Helpers.loadSpriteFromResources("TheOtherRoles.Resources.CleanButton.png", 115f);
                 return buttonSprite;
             }
 
-            public static void clearAndReload() {
+            public static void clearAndReload()
+            {
                 janitor = null;
                 cooldown = CustomOptionHolder.janitorCooldown.getFloat();
             }
         }
 
-        public static class Sheriff {
+        public static class Sheriff
+        {
             public static PlayerControl sheriff;
             public static Color color = new Color32(248, 205, 70, byte.MaxValue);
 
@@ -236,7 +257,8 @@ namespace TheOtherRoles
                 cooldown = CustomOptionHolder.sheriffCooldown.getFloat();
             }
 
-            public static void clearAndReload() {
+            public static void clearAndReload()
+            {
                 sheriff = null;
                 currentTarget = null;
                 formerDeputy = null;
@@ -264,7 +286,7 @@ namespace TheOtherRoles
 
             private static Sprite buttonSprite;
             private static Sprite handcuffedSprite;
-            
+
             public static Sprite getButtonSprite()
             {
                 if (buttonSprite) return buttonSprite;
@@ -282,7 +304,8 @@ namespace TheOtherRoles
             // Can be used to enable / disable the handcuff effect on the target's buttons
             public static void setHandcuffedKnows(bool active = true)
             {
-                if (active) {
+                if (active)
+                {
                     byte localPlayerId = CachedPlayer.LocalPlayer.PlayerId;
                     handcuffedKnows.Add(localPlayerId, handcuffDuration);
                     handcuffedPlayers.RemoveAll(x => x == localPlayerId);
@@ -307,10 +330,11 @@ namespace TheOtherRoles
             }
         }
 
-        public static class Lighter {
+        public static class Lighter
+        {
             public static PlayerControl lighter;
             public static Color color = new Color32(238, 229, 190, byte.MaxValue);
-            
+
             public static float lighterModeLightsOnVision = 2f;
             public static float lighterModeLightsOffVision = 0.75f;
 
@@ -320,13 +344,15 @@ namespace TheOtherRoles
             public static float lighterTimer = 0f;
 
             private static Sprite buttonSprite;
-            public static Sprite getButtonSprite() {
+            public static Sprite getButtonSprite()
+            {
                 if (buttonSprite) return buttonSprite;
                 buttonSprite = Helpers.loadSpriteFromResources("TheOtherRoles.Resources.LighterButton.png", 115f);
                 return buttonSprite;
             }
 
-            public static void clearAndReload() {
+            public static void clearAndReload()
+            {
                 lighter = null;
                 lighterTimer = 0f;
                 cooldown = CustomOptionHolder.lighterCooldown.getFloat();
@@ -336,7 +362,8 @@ namespace TheOtherRoles
             }
         }
 
-        public static class Detective {
+        public static class Detective
+        {
             public static PlayerControl detective;
             public static Color color = new Color32(45, 106, 165, byte.MaxValue);
 
@@ -347,7 +374,8 @@ namespace TheOtherRoles
             public static float reportColorDuration = 20f;
             public static float timer = 6.2f;
 
-            public static void clearAndReload() {
+            public static void clearAndReload()
+            {
                 detective = null;
                 anonymousFootprints = CustomOptionHolder.detectiveAnonymousFootprints.getBool();
                 footprintIntervall = CustomOptionHolder.detectiveFootprintIntervall.getFloat();
@@ -359,7 +387,8 @@ namespace TheOtherRoles
         }
     }
 
-    public static class TimeMaster {
+    public static class TimeMaster
+    {
         public static PlayerControl timeMaster;
         public static Color color = new Color32(112, 142, 239, byte.MaxValue);
 
@@ -372,13 +401,15 @@ namespace TheOtherRoles
         public static bool isRewinding = false;
 
         private static Sprite buttonSprite;
-        public static Sprite getButtonSprite() {
+        public static Sprite getButtonSprite()
+        {
             if (buttonSprite) return buttonSprite;
             buttonSprite = Helpers.loadSpriteFromResources("TheOtherRoles.Resources.TimeShieldButton.png", 115f);
             return buttonSprite;
         }
 
-        public static void clearAndReload() {
+        public static void clearAndReload()
+        {
             timeMaster = null;
             isRewinding = false;
             shieldActive = false;
@@ -388,11 +419,12 @@ namespace TheOtherRoles
         }
     }
 
-    public static class Medic {
+    public static class Medic
+    {
         public static PlayerControl medic;
         public static PlayerControl shielded;
         public static PlayerControl futureShielded;
-        
+
         public static Color color = new Color32(126, 251, 194, byte.MaxValue);
         public static bool usedShield;
 
@@ -407,13 +439,15 @@ namespace TheOtherRoles
         public static PlayerControl currentTarget;
 
         private static Sprite buttonSprite;
-        public static Sprite getButtonSprite() {
+        public static Sprite getButtonSprite()
+        {
             if (buttonSprite) return buttonSprite;
             buttonSprite = Helpers.loadSpriteFromResources("TheOtherRoles.Resources.ShieldButton.png", 115f);
             return buttonSprite;
         }
 
-        public static void clearAndReload() {
+        public static void clearAndReload()
+        {
             medic = null;
             shielded = null;
             futureShielded = null;
@@ -428,7 +462,8 @@ namespace TheOtherRoles
         }
     }
 
-    public static class Shifter {
+    public static class Shifter
+    {
         public static PlayerControl shifter;
         public static Color color = new Color32(102, 102, 102, byte.MaxValue);
 
@@ -437,13 +472,15 @@ namespace TheOtherRoles
         public static bool shiftModifiers = false;
 
         private static Sprite buttonSprite;
-        public static Sprite getButtonSprite() {
+        public static Sprite getButtonSprite()
+        {
             if (buttonSprite) return buttonSprite;
             buttonSprite = Helpers.loadSpriteFromResources("TheOtherRoles.Resources.ShiftButton.png", 115f);
             return buttonSprite;
         }
 
-        public static void clearAndReload() {
+        public static void clearAndReload()
+        {
             shifter = null;
             currentTarget = null;
             futureShift = null;
@@ -451,7 +488,8 @@ namespace TheOtherRoles
         }
     }
 
-    public static class Swapper {
+    public static class Swapper
+    {
         public static PlayerControl swapper;
         public static Color color = new Color32(134, 55, 86, byte.MaxValue);
         private static Sprite spriteCheck;
@@ -460,17 +498,19 @@ namespace TheOtherRoles
         public static int charges;
         public static float rechargeTasksNumber;
         public static float rechargedTasks;
- 
+
         public static byte playerId1 = Byte.MaxValue;
         public static byte playerId2 = Byte.MaxValue;
 
-        public static Sprite getCheckSprite() {
+        public static Sprite getCheckSprite()
+        {
             if (spriteCheck) return spriteCheck;
             spriteCheck = Helpers.loadSpriteFromResources("TheOtherRoles.Resources.SwapperCheck.png", 150f);
             return spriteCheck;
         }
 
-        public static void clearAndReload() {
+        public static void clearAndReload()
+        {
             swapper = null;
             playerId1 = Byte.MaxValue;
             playerId2 = Byte.MaxValue;
@@ -482,7 +522,8 @@ namespace TheOtherRoles
         }
     }
 
-    public static class Lovers {
+    public static class Lovers
+    {
         public static PlayerControl lover1;
         public static PlayerControl lover2;
         public static Color color = new Color32(232, 57, 185, byte.MaxValue);
@@ -492,27 +533,32 @@ namespace TheOtherRoles
         // Lovers save if next to be exiled is a lover, because RPC of ending game comes before RPC of exiled
         public static bool notAckedExiledIsLover = false;
 
-        public static bool existing() {
+        public static bool existing()
+        {
             return lover1 != null && lover2 != null && !lover1.Data.Disconnected && !lover2.Data.Disconnected;
         }
 
-        public static bool existingAndAlive() {
+        public static bool existingAndAlive()
+        {
             return existing() && !lover1.Data.IsDead && !lover2.Data.IsDead && !notAckedExiledIsLover; // ADD NOT ACKED IS LOVER
         }
 
-        public static bool existingWithKiller() {
-            return existing() && (lover1 == Jackal.jackal     || lover2 == Jackal.jackal
+        public static bool existingWithKiller()
+        {
+            return existing() && (lover1 == Jackal.jackal || lover2 == Jackal.jackal
                                || lover1 == Sidekick.sidekick || lover2 == Sidekick.sidekick
-                               || lover1.Data.Role.IsImpostor      || lover2.Data.Role.IsImpostor);
+                               || lover1.Data.Role.IsImpostor || lover2.Data.Role.IsImpostor);
         }
 
-        public static bool hasAliveKillingLover(this PlayerControl player) {
+        public static bool hasAliveKillingLover(this PlayerControl player)
+        {
             if (!Lovers.existingAndAlive() || !existingWithKiller())
                 return false;
             return (player != null && (player == lover1 || player == lover2));
         }
 
-        public static void clearAndReload() {
+        public static void clearAndReload()
+        {
             lover1 = null;
             lover2 = null;
             notAckedExiledIsLover = false;
@@ -520,7 +566,8 @@ namespace TheOtherRoles
             enableChat = CustomOptionHolder.modifierLoverEnableChat.getBool();
         }
 
-        public static PlayerControl getPartner(this PlayerControl player) {
+        public static PlayerControl getPartner(this PlayerControl player)
+        {
             if (player == null)
                 return null;
             if (lover1 == player)
@@ -531,7 +578,8 @@ namespace TheOtherRoles
         }
     }
 
-    public static class Seer {
+    public static class Seer
+    {
         public static PlayerControl seer;
         public static Color color = new Color32(97, 178, 108, byte.MaxValue);
         public static List<Vector3> deadBodyPositions = new List<Vector3>();
@@ -541,13 +589,15 @@ namespace TheOtherRoles
         public static int mode = 0;
 
         private static Sprite soulSprite;
-        public static Sprite getSoulSprite() {
+        public static Sprite getSoulSprite()
+        {
             if (soulSprite) return soulSprite;
             soulSprite = Helpers.loadSpriteFromResources("TheOtherRoles.Resources.Soul.png", 500f);
             return soulSprite;
         }
 
-        public static void clearAndReload() {
+        public static void clearAndReload()
+        {
             seer = null;
             deadBodyPositions = new List<Vector3>();
             limitSoulDuration = CustomOptionHolder.seerLimitSoulDuration.getBool();
@@ -556,12 +606,13 @@ namespace TheOtherRoles
         }
     }
 
-    public static class Morphling {
+    public static class Morphling
+    {
         public static PlayerControl morphling;
         public static Color color = Palette.ImpostorRed;
         private static Sprite sampleSprite;
         private static Sprite morphSprite;
-    
+
         public static float cooldown = 30f;
         public static float duration = 10f;
 
@@ -570,14 +621,16 @@ namespace TheOtherRoles
         public static PlayerControl morphTarget;
         public static float morphTimer = 0f;
 
-        public static void resetMorph() {
+        public static void resetMorph()
+        {
             morphTarget = null;
             morphTimer = 0f;
             if (morphling == null) return;
             morphling.setDefaultLook();
         }
 
-        public static void clearAndReload() {
+        public static void clearAndReload()
+        {
             resetMorph();
             morphling = null;
             currentTarget = null;
@@ -588,41 +641,47 @@ namespace TheOtherRoles
             duration = CustomOptionHolder.morphlingDuration.getFloat();
         }
 
-        public static Sprite getSampleSprite() {
+        public static Sprite getSampleSprite()
+        {
             if (sampleSprite) return sampleSprite;
             sampleSprite = Helpers.loadSpriteFromResources("TheOtherRoles.Resources.SampleButton.png", 115f);
             return sampleSprite;
         }
 
-        public static Sprite getMorphSprite() {
+        public static Sprite getMorphSprite()
+        {
             if (morphSprite) return morphSprite;
             morphSprite = Helpers.loadSpriteFromResources("TheOtherRoles.Resources.MorphButton.png", 115f);
             return morphSprite;
         }
     }
 
-    public static class Camouflager {
+    public static class Camouflager
+    {
         public static PlayerControl camouflager;
         public static Color color = Palette.ImpostorRed;
-    
+
         public static float cooldown = 30f;
         public static float duration = 10f;
         public static float camouflageTimer = 0f;
 
         private static Sprite buttonSprite;
-        public static Sprite getButtonSprite() {
+        public static Sprite getButtonSprite()
+        {
             if (buttonSprite) return buttonSprite;
             buttonSprite = Helpers.loadSpriteFromResources("TheOtherRoles.Resources.CamoButton.png", 115f);
             return buttonSprite;
         }
 
-        public static void resetCamouflage() {
+        public static void resetCamouflage()
+        {
             camouflageTimer = 0f;
             foreach (PlayerControl p in CachedPlayer.AllPlayers)
                 p.setDefaultLook();
         }
 
-        public static void clearAndReload() {
+        public static void clearAndReload()
+        {
             resetCamouflage();
             camouflager = null;
             camouflageTimer = 0f;
@@ -631,7 +690,8 @@ namespace TheOtherRoles
         }
     }
 
-    public static class Hacker {
+    public static class Hacker
+    {
         public static PlayerControl hacker;
         public static Minigame vitals = null;
         public static Minigame doorLog = null;
@@ -653,25 +713,29 @@ namespace TheOtherRoles
         private static Sprite logSprite;
         private static Sprite adminSprite;
 
-        public static Sprite getButtonSprite() {
+        public static Sprite getButtonSprite()
+        {
             if (buttonSprite) return buttonSprite;
             buttonSprite = Helpers.loadSpriteFromResources("TheOtherRoles.Resources.HackerButton.png", 115f);
             return buttonSprite;
         }
 
-        public static Sprite getVitalsSprite() {
+        public static Sprite getVitalsSprite()
+        {
             if (vitalsSprite) return vitalsSprite;
             vitalsSprite = FastDestroyableSingleton<HudManager>.Instance.UseButton.fastUseSettings[ImageNames.VitalsButton].Image;
             return vitalsSprite;
         }
 
-        public static Sprite getLogSprite() {
+        public static Sprite getLogSprite()
+        {
             if (logSprite) return logSprite;
             logSprite = FastDestroyableSingleton<HudManager>.Instance.UseButton.fastUseSettings[ImageNames.DoorLogsButton].Image;
             return logSprite;
         }
 
-        public static Sprite getAdminSprite() {
+        public static Sprite getAdminSprite()
+        {
             byte mapId = PlayerControl.GameOptions.MapId;
             UseButtonSettings button = FastDestroyableSingleton<HudManager>.Instance.UseButton.fastUseSettings[ImageNames.PolusAdminButton]; // Polus
             if (mapId == 0 || mapId == 3) button = FastDestroyableSingleton<HudManager>.Instance.UseButton.fastUseSettings[ImageNames.AdminMapButton]; // Skeld || Dleks
@@ -681,7 +745,8 @@ namespace TheOtherRoles
             return adminSprite;
         }
 
-        public static void clearAndReload() {
+        public static void clearAndReload()
+        {
             hacker = null;
             vitals = null;
             doorLog = null;
@@ -699,7 +764,8 @@ namespace TheOtherRoles
         }
     }
 
-    public static class Tracker {
+    public static class Tracker
+    {
         public static PlayerControl tracker;
         public static Color color = new Color32(100, 58, 220, byte.MaxValue);
         public static List<Arrow> localArrows = new List<Arrow>();
@@ -727,13 +793,15 @@ namespace TheOtherRoles
         }
 
         private static Sprite buttonSprite;
-        public static Sprite getButtonSprite() {
+        public static Sprite getButtonSprite()
+        {
             if (buttonSprite) return buttonSprite;
             buttonSprite = Helpers.loadSpriteFromResources("TheOtherRoles.Resources.TrackerButton.png", 115f);
             return buttonSprite;
         }
 
-        public static void resetTracked() {
+        public static void resetTracked()
+        {
             currentTarget = tracked = null;
             usedTracker = false;
             if (arrow?.arrow != null) UnityEngine.Object.Destroy(arrow.arrow);
@@ -741,13 +809,15 @@ namespace TheOtherRoles
             if (arrow.arrow != null) arrow.arrow.SetActive(false);
         }
 
-        public static void clearAndReload() {
+        public static void clearAndReload()
+        {
             tracker = null;
             resetTracked();
             timeUntilUpdate = 0f;
             updateIntervall = CustomOptionHolder.trackerUpdateIntervall.getFloat();
             resetTargetAfterMeeting = CustomOptionHolder.trackerResetTargetAfterMeeting.getBool();
-            if (localArrows != null) {
+            if (localArrows != null)
+            {
                 foreach (Arrow arrow in localArrows)
                     if (arrow?.arrow != null)
                         UnityEngine.Object.Destroy(arrow.arrow);
@@ -760,7 +830,8 @@ namespace TheOtherRoles
         }
     }
 
-    public static class Vampire {
+    public static class Vampire
+    {
         public static PlayerControl vampire;
         public static Color color = Palette.ImpostorRed;
 
@@ -771,24 +842,27 @@ namespace TheOtherRoles
         public static bool garlicsActive = true;
 
         public static PlayerControl currentTarget;
-        public static PlayerControl bitten; 
+        public static PlayerControl bitten;
         public static bool targetNearGarlic = false;
 
         private static Sprite buttonSprite;
-        public static Sprite getButtonSprite() {
+        public static Sprite getButtonSprite()
+        {
             if (buttonSprite) return buttonSprite;
             buttonSprite = Helpers.loadSpriteFromResources("TheOtherRoles.Resources.VampireButton.png", 115f);
             return buttonSprite;
         }
 
         private static Sprite garlicButtonSprite;
-        public static Sprite getGarlicButtonSprite() {
+        public static Sprite getGarlicButtonSprite()
+        {
             if (garlicButtonSprite) return garlicButtonSprite;
             garlicButtonSprite = Helpers.loadSpriteFromResources("TheOtherRoles.Resources.GarlicButton.png", 115f);
             return garlicButtonSprite;
         }
 
-        public static void clearAndReload() {
+        public static void clearAndReload()
+        {
             vampire = null;
             bitten = null;
             targetNearGarlic = false;
@@ -801,7 +875,8 @@ namespace TheOtherRoles
         }
     }
 
-    public static class Snitch {
+    public static class Snitch
+    {
         public static PlayerControl snitch;
         public static Color color = new Color32(184, 251, 79, byte.MaxValue);
 
@@ -811,11 +886,13 @@ namespace TheOtherRoles
         public static bool teamJackalUseDifferentArrowColor = true;
 
 
-        public static void clearAndReload() {
-            if (localArrows != null) {
+        public static void clearAndReload()
+        {
+            if (localArrows != null)
+            {
                 foreach (Arrow arrow in localArrows)
                     if (arrow?.arrow != null)
-                    UnityEngine.Object.Destroy(arrow.arrow);
+                        UnityEngine.Object.Destroy(arrow.arrow);
             }
             localArrows = new List<Arrow>();
             taskCountForReveal = Mathf.RoundToInt(CustomOptionHolder.snitchLeftTasksForReveal.getFloat());
@@ -825,13 +902,14 @@ namespace TheOtherRoles
         }
     }
 
-    public static class Jackal {
+    public static class Jackal
+    {
         public static PlayerControl jackal;
         public static Color color = new Color32(0, 180, 235, byte.MaxValue);
         public static PlayerControl fakeSidekick;
         public static PlayerControl currentTarget;
         public static List<PlayerControl> formerJackals = new List<PlayerControl>();
-        
+
         public static float cooldown = 30f;
         public static float createSidekickCooldown = 30f;
         public static bool canUseVents = true;
@@ -844,13 +922,15 @@ namespace TheOtherRoles
         public static bool wasImpostor;
         public static bool wasSpy;
 
-        public static Sprite getSidekickButtonSprite() {
+        public static Sprite getSidekickButtonSprite()
+        {
             if (buttonSprite) return buttonSprite;
             buttonSprite = Helpers.loadSpriteFromResources("TheOtherRoles.Resources.SidekickButton.png", 115f);
             return buttonSprite;
         }
 
-        public static void removeCurrentJackal() {
+        public static void removeCurrentJackal()
+        {
             if (!formerJackals.Any(x => x.PlayerId == jackal.PlayerId)) formerJackals.Add(jackal);
             jackal = null;
             currentTarget = null;
@@ -859,7 +939,8 @@ namespace TheOtherRoles
             createSidekickCooldown = CustomOptionHolder.jackalCreateSidekickCooldown.getFloat();
         }
 
-        public static void clearAndReload() {
+        public static void clearAndReload()
+        {
             jackal = null;
             currentTarget = null;
             fakeSidekick = null;
@@ -873,10 +954,11 @@ namespace TheOtherRoles
             hasImpostorVision = CustomOptionHolder.jackalAndSidekickHaveImpostorVision.getBool();
             wasTeamRed = wasImpostor = wasSpy = false;
         }
-        
+
     }
 
-    public static class Sidekick {
+    public static class Sidekick
+    {
         public static PlayerControl sidekick;
         public static Color color = new Color32(0, 180, 235, byte.MaxValue);
 
@@ -892,7 +974,8 @@ namespace TheOtherRoles
         public static bool promotesToJackal = true;
         public static bool hasImpostorVision = false;
 
-        public static void clearAndReload() {
+        public static void clearAndReload()
+        {
             sidekick = null;
             currentTarget = null;
             cooldown = CustomOptionHolder.jackalKillCooldown.getFloat();
@@ -904,23 +987,26 @@ namespace TheOtherRoles
         }
     }
 
-    public static class Eraser {
+    public static class Eraser
+    {
         public static PlayerControl eraser;
         public static Color color = Palette.ImpostorRed;
 
         public static List<PlayerControl> futureErased = new List<PlayerControl>();
         public static PlayerControl currentTarget;
         public static float cooldown = 30f;
-        public static bool canEraseAnyone = false; 
+        public static bool canEraseAnyone = false;
 
         private static Sprite buttonSprite;
-        public static Sprite getButtonSprite() {
+        public static Sprite getButtonSprite()
+        {
             if (buttonSprite) return buttonSprite;
             buttonSprite = Helpers.loadSpriteFromResources("TheOtherRoles.Resources.EraserButton.png", 115f);
             return buttonSprite;
         }
 
-        public static void clearAndReload() {
+        public static void clearAndReload()
+        {
             eraser = null;
             futureErased = new List<PlayerControl>();
             currentTarget = null;
@@ -928,8 +1014,9 @@ namespace TheOtherRoles
             canEraseAnyone = CustomOptionHolder.eraserCanEraseAnyone.getBool();
         }
     }
-    
-    public static class Spy {
+
+    public static class Spy
+    {
         public static PlayerControl spy;
         public static Color color = Palette.ImpostorRed;
 
@@ -937,7 +1024,8 @@ namespace TheOtherRoles
         public static bool canEnterVents = false;
         public static bool hasImpostorVision = false;
 
-        public static void clearAndReload() {
+        public static void clearAndReload()
+        {
             spy = null;
             impostorsCanKillAnyone = CustomOptionHolder.spyImpostorsCanKillAnyone.getBool();
             canEnterVents = CustomOptionHolder.spyCanEnterVents.getBool();
@@ -945,7 +1033,8 @@ namespace TheOtherRoles
         }
     }
 
-    public static class Trickster {
+    public static class Trickster
+    {
         public static PlayerControl trickster;
         public static Color color = Palette.ImpostorRed;
         public static float placeBoxCooldown = 30f;
@@ -957,25 +1046,29 @@ namespace TheOtherRoles
         private static Sprite lightOutButtonSprite;
         private static Sprite tricksterVentButtonSprite;
 
-        public static Sprite getPlaceBoxButtonSprite() {
+        public static Sprite getPlaceBoxButtonSprite()
+        {
             if (placeBoxButtonSprite) return placeBoxButtonSprite;
             placeBoxButtonSprite = Helpers.loadSpriteFromResources("TheOtherRoles.Resources.PlaceJackInTheBoxButton.png", 115f);
             return placeBoxButtonSprite;
         }
 
-        public static Sprite getLightsOutButtonSprite() {
+        public static Sprite getLightsOutButtonSprite()
+        {
             if (lightOutButtonSprite) return lightOutButtonSprite;
             lightOutButtonSprite = Helpers.loadSpriteFromResources("TheOtherRoles.Resources.LightsOutButton.png", 115f);
             return lightOutButtonSprite;
         }
 
-        public static Sprite getTricksterVentButtonSprite() {
+        public static Sprite getTricksterVentButtonSprite()
+        {
             if (tricksterVentButtonSprite) return tricksterVentButtonSprite;
             tricksterVentButtonSprite = Helpers.loadSpriteFromResources("TheOtherRoles.Resources.TricksterVentButton.png", 115f);
             return tricksterVentButtonSprite;
         }
 
-        public static void clearAndReload() {
+        public static void clearAndReload()
+        {
             trickster = null;
             lightsOutTimer = 0f;
             placeBoxCooldown = CustomOptionHolder.tricksterPlaceBoxCooldown.getFloat();
@@ -986,26 +1079,30 @@ namespace TheOtherRoles
 
     }
 
-    public static class Cleaner {
+    public static class Cleaner
+    {
         public static PlayerControl cleaner;
         public static Color color = Palette.ImpostorRed;
 
         public static float cooldown = 30f;
 
         private static Sprite buttonSprite;
-        public static Sprite getButtonSprite() {
+        public static Sprite getButtonSprite()
+        {
             if (buttonSprite) return buttonSprite;
             buttonSprite = Helpers.loadSpriteFromResources("TheOtherRoles.Resources.CleanButton.png", 115f);
             return buttonSprite;
         }
 
-        public static void clearAndReload() {
+        public static void clearAndReload()
+        {
             cleaner = null;
             cooldown = CustomOptionHolder.cleanerCooldown.getFloat();
         }
     }
 
-    public static class Warlock {
+    public static class Warlock
+    {
 
         public static PlayerControl warlock;
         public static Color color = Palette.ImpostorRed;
@@ -1020,19 +1117,22 @@ namespace TheOtherRoles
         private static Sprite curseButtonSprite;
         private static Sprite curseKillButtonSprite;
 
-        public static Sprite getCurseButtonSprite() {
+        public static Sprite getCurseButtonSprite()
+        {
             if (curseButtonSprite) return curseButtonSprite;
             curseButtonSprite = Helpers.loadSpriteFromResources("TheOtherRoles.Resources.CurseButton.png", 115f);
             return curseButtonSprite;
         }
 
-        public static Sprite getCurseKillButtonSprite() {
+        public static Sprite getCurseKillButtonSprite()
+        {
             if (curseKillButtonSprite) return curseKillButtonSprite;
             curseKillButtonSprite = Helpers.loadSpriteFromResources("TheOtherRoles.Resources.CurseKillButton.png", 115f);
             return curseKillButtonSprite;
         }
 
-        public static void clearAndReload() {
+        public static void clearAndReload()
+        {
             warlock = null;
             currentTarget = null;
             curseVictim = null;
@@ -1041,7 +1141,8 @@ namespace TheOtherRoles
             rootTime = CustomOptionHolder.warlockRootTime.getFloat();
         }
 
-        public static void resetCurse() {
+        public static void resetCurse()
+        {
             HudManagerStartPatch.warlockCurseButton.Timer = HudManagerStartPatch.warlockCurseButton.MaxTimer;
             HudManagerStartPatch.warlockCurseButton.Sprite = Warlock.getCurseButtonSprite();
             HudManagerStartPatch.warlockCurseButton.actionButton.cooldownTimerText.color = Palette.EnabledColor;
@@ -1051,7 +1152,8 @@ namespace TheOtherRoles
         }
     }
 
-    public static class SecurityGuard {
+    public static class SecurityGuard
+    {
         public static PlayerControl securityGuard;
         public static Color color = new Color32(195, 178, 95, byte.MaxValue);
 
@@ -1071,14 +1173,16 @@ namespace TheOtherRoles
         public static Minigame minigame = null;
 
         private static Sprite closeVentButtonSprite;
-        public static Sprite getCloseVentButtonSprite() {
+        public static Sprite getCloseVentButtonSprite()
+        {
             if (closeVentButtonSprite) return closeVentButtonSprite;
             closeVentButtonSprite = Helpers.loadSpriteFromResources("TheOtherRoles.Resources.CloseVentButton.png", 115f);
             return closeVentButtonSprite;
         }
 
         private static Sprite placeCameraButtonSprite;
-        public static Sprite getPlaceCameraButtonSprite() {
+        public static Sprite getPlaceCameraButtonSprite()
+        {
             if (placeCameraButtonSprite) return placeCameraButtonSprite;
             placeCameraButtonSprite = Helpers.loadSpriteFromResources("TheOtherRoles.Resources.PlaceCameraButton.png", 115f);
             return placeCameraButtonSprite;
@@ -1086,10 +1190,12 @@ namespace TheOtherRoles
 
         private static Sprite animatedVentSealedSprite;
         private static float lastPPU;
-        public static Sprite getAnimatedVentSealedSprite() {
+        public static Sprite getAnimatedVentSealedSprite()
+        {
             float ppu = 185f;
             if (SubmergedCompatibility.IsSubmerged) ppu = 120f;
-            if (lastPPU != ppu) {
+            if (lastPPU != ppu)
+            {
                 animatedVentSealedSprite = null;
                 lastPPU = ppu;
             }
@@ -1099,41 +1205,47 @@ namespace TheOtherRoles
         }
 
         private static Sprite staticVentSealedSprite;
-        public static Sprite getStaticVentSealedSprite() {
+        public static Sprite getStaticVentSealedSprite()
+        {
             if (staticVentSealedSprite) return staticVentSealedSprite;
             staticVentSealedSprite = Helpers.loadSpriteFromResources("TheOtherRoles.Resources.StaticVentSealed.png", 160f);
             return staticVentSealedSprite;
         }
 
         private static Sprite submergedCentralUpperVentSealedSprite;
-        public static Sprite getSubmergedCentralUpperSealedSprite() {
+        public static Sprite getSubmergedCentralUpperSealedSprite()
+        {
             if (submergedCentralUpperVentSealedSprite) return submergedCentralUpperVentSealedSprite;
             submergedCentralUpperVentSealedSprite = Helpers.loadSpriteFromResources("TheOtherRoles.Resources.CentralUpperBlocked.png", 145f);
             return submergedCentralUpperVentSealedSprite;
         }
 
         private static Sprite submergedCentralLowerVentSealedSprite;
-        public static Sprite getSubmergedCentralLowerSealedSprite() {
+        public static Sprite getSubmergedCentralLowerSealedSprite()
+        {
             if (submergedCentralLowerVentSealedSprite) return submergedCentralLowerVentSealedSprite;
             submergedCentralLowerVentSealedSprite = Helpers.loadSpriteFromResources("TheOtherRoles.Resources.CentralLowerBlocked.png", 145f);
             return submergedCentralLowerVentSealedSprite;
         }
 
         private static Sprite camSprite;
-        public static Sprite getCamSprite() {
+        public static Sprite getCamSprite()
+        {
             if (camSprite) return camSprite;
             camSprite = FastDestroyableSingleton<HudManager>.Instance.UseButton.fastUseSettings[ImageNames.CamsButton].Image;
             return camSprite;
         }
 
         private static Sprite logSprite;
-        public static Sprite getLogSprite() {
+        public static Sprite getLogSprite()
+        {
             if (logSprite) return logSprite;
             logSprite = FastDestroyableSingleton<HudManager>.Instance.UseButton.fastUseSettings[ImageNames.DoorLogsButton].Image;
             return logSprite;
         }
 
-        public static void clearAndReload() {
+        public static void clearAndReload()
+        {
             securityGuard = null;
             ventTarget = null;
             minigame = null;
@@ -1141,7 +1253,7 @@ namespace TheOtherRoles
             maxCharges = Mathf.RoundToInt(CustomOptionHolder.securityGuardCamMaxCharges.getFloat());
             rechargeTasksNumber = Mathf.RoundToInt(CustomOptionHolder.securityGuardCamRechargeTasksNumber.getFloat());
             rechargedTasks = Mathf.RoundToInt(CustomOptionHolder.securityGuardCamRechargeTasksNumber.getFloat());
-            charges = Mathf.RoundToInt(CustomOptionHolder.securityGuardCamMaxCharges.getFloat()) /2;
+            charges = Mathf.RoundToInt(CustomOptionHolder.securityGuardCamMaxCharges.getFloat()) / 2;
             placedCameras = 0;
             cooldown = CustomOptionHolder.securityGuardCooldown.getFloat();
             totalScrews = remainingScrews = Mathf.RoundToInt(CustomOptionHolder.securityGuardTotalScrews.getFloat());
@@ -1151,7 +1263,8 @@ namespace TheOtherRoles
         }
     }
 
-    public static class Arsonist {
+    public static class Arsonist
+    {
         public static PlayerControl arsonist;
         public static Color color = new Color32(238, 112, 46, byte.MaxValue);
 
@@ -1164,30 +1277,35 @@ namespace TheOtherRoles
         public static List<PlayerControl> dousedPlayers = new List<PlayerControl>();
 
         private static Sprite douseSprite;
-        public static Sprite getDouseSprite() {
+        public static Sprite getDouseSprite()
+        {
             if (douseSprite) return douseSprite;
             douseSprite = Helpers.loadSpriteFromResources("TheOtherRoles.Resources.DouseButton.png", 115f);
             return douseSprite;
         }
 
         private static Sprite igniteSprite;
-        public static Sprite getIgniteSprite() {
+        public static Sprite getIgniteSprite()
+        {
             if (igniteSprite) return igniteSprite;
             igniteSprite = Helpers.loadSpriteFromResources("TheOtherRoles.Resources.IgniteButton.png", 115f);
             return igniteSprite;
         }
 
-        public static bool dousedEveryoneAlive() {
+        public static bool dousedEveryoneAlive()
+        {
             return CachedPlayer.AllPlayers.All(x => { return x.PlayerControl == Arsonist.arsonist || x.Data.IsDead || x.Data.Disconnected || Arsonist.dousedPlayers.Any(y => y.PlayerId == x.PlayerId); });
         }
 
-        public static void clearAndReload() {
+        public static void clearAndReload()
+        {
             arsonist = null;
             currentTarget = null;
-            douseTarget = null; 
+            douseTarget = null;
             triggerArsonistWin = false;
             dousedPlayers = new List<PlayerControl>();
-            foreach (PoolablePlayer p in MapOptions.playerIcons.Values) {
+            foreach (PoolablePlayer p in MapOptions.playerIcons.Values)
+            {
                 if (p != null && p.gameObject != null) p.gameObject.SetActive(false);
             }
             cooldown = CustomOptionHolder.arsonistCooldown.getFloat();
@@ -1195,7 +1313,8 @@ namespace TheOtherRoles
         }
     }
 
-    public static class Guesser {
+    public static class Guesser
+    {
         public static PlayerControl niceGuesser;
         public static PlayerControl evilGuesser;
         public static Color color = new Color32(255, 255, 0, byte.MaxValue);
@@ -1208,34 +1327,42 @@ namespace TheOtherRoles
         public static bool killsThroughShield = true;
         public static bool evilGuesserCanGuessSpy = true;
         public static bool guesserCantGuessSnitch = false;
-        public static Sprite getTargetSprite() {
+        public static Sprite getTargetSprite()
+        {
             if (targetSprite) return targetSprite;
             targetSprite = Helpers.loadSpriteFromResources("TheOtherRoles.Resources.TargetIcon.png", 150f);
             return targetSprite;
         }
 
-        public static bool isGuesser (byte playerId) {
+        public static bool isGuesser(byte playerId)
+        {
             if ((niceGuesser != null && niceGuesser.PlayerId == playerId) || (evilGuesser != null && evilGuesser.PlayerId == playerId)) return true;
             return false;
         }
 
-        public static void clear (byte playerId) {
+        public static void clear(byte playerId)
+        {
             if (niceGuesser != null && niceGuesser.PlayerId == playerId) niceGuesser = null;
             else if (evilGuesser != null && evilGuesser.PlayerId == playerId) evilGuesser = null;
         }
 
-        public static int remainingShots(byte playerId, bool shoot = false) {
+        public static int remainingShots(byte playerId, bool shoot = false)
+        {
             int remainingShots = remainingShotsEvilGuesser;
-            if (niceGuesser != null && niceGuesser.PlayerId == playerId) {
+            if (niceGuesser != null && niceGuesser.PlayerId == playerId)
+            {
                 remainingShots = remainingShotsNiceGuesser;
                 if (shoot) remainingShotsNiceGuesser = Mathf.Max(0, remainingShotsNiceGuesser - 1);
-            } else if (shoot) {
+            }
+            else if (shoot)
+            {
                 remainingShotsEvilGuesser = Mathf.Max(0, remainingShotsEvilGuesser - 1);
             }
             return remainingShots;
         }
 
-        public static void clearAndReload() {
+        public static void clearAndReload()
+        {
             niceGuesser = null;
             evilGuesser = null;
             guesserCantGuessSnitch = CustomOptionHolder.guesserCantGuessSnitchIfTaksDone.getBool();
@@ -1248,7 +1375,8 @@ namespace TheOtherRoles
         }
     }
 
-    public static class BountyHunter {
+    public static class BountyHunter
+    {
         public static PlayerControl bountyHunter;
         public static Color color = Palette.ImpostorRed;
 
@@ -1264,7 +1392,8 @@ namespace TheOtherRoles
         public static PlayerControl bounty;
         public static TMPro.TextMeshPro cooldownText;
 
-        public static void clearAndReload() {
+        public static void clearAndReload()
+        {
             arrow = new Arrow(color);
             bountyHunter = null;
             bounty = null;
@@ -1274,7 +1403,8 @@ namespace TheOtherRoles
             arrow = null;
             if (cooldownText != null && cooldownText.gameObject != null) UnityEngine.Object.Destroy(cooldownText.gameObject);
             cooldownText = null;
-            foreach (PoolablePlayer p in MapOptions.playerIcons.Values) {
+            foreach (PoolablePlayer p in MapOptions.playerIcons.Values)
+            {
                 if (p != null && p.gameObject != null) p.gameObject.SetActive(false);
             }
 
@@ -1287,7 +1417,8 @@ namespace TheOtherRoles
         }
     }
 
-    public static class Vulture {
+    public static class Vulture
+    {
         public static PlayerControl vulture;
         public static Color color = new Color32(139, 69, 19, byte.MaxValue);
         public static List<Arrow> localArrows = new List<Arrow>();
@@ -1298,21 +1429,25 @@ namespace TheOtherRoles
         public static bool canUseVents = true;
         public static bool showArrows = true;
         private static Sprite buttonSprite;
-        public static Sprite getButtonSprite() {
+        public static Sprite getButtonSprite()
+        {
             if (buttonSprite) return buttonSprite;
             buttonSprite = Helpers.loadSpriteFromResources("TheOtherRoles.Resources.VultureButton.png", 115f);
             return buttonSprite;
         }
 
-        public static void clearAndReload() {
+        public static void clearAndReload()
+        {
             vulture = null;
-            vultureNumberToWin = Mathf.RoundToInt(CustomOptionHolder.vultureNumberToWin.getFloat());
+            var playerCount = GameData.Instance.PlayerCount;
+            vultureNumberToWin = (int)Mathf.Floor((float)playerCount / (float)3.0);
             eatenBodies = 0;
             cooldown = CustomOptionHolder.vultureCooldown.getFloat();
             triggerVultureWin = false;
             canUseVents = CustomOptionHolder.vultureCanUseVents.getBool();
             showArrows = CustomOptionHolder.vultureShowArrows.getBool();
-            if (localArrows != null) {
+            if (localArrows != null)
+            {
                 foreach (Arrow arrow in localArrows)
                     if (arrow?.arrow != null)
                         UnityEngine.Object.Destroy(arrow.arrow);
@@ -1322,7 +1457,8 @@ namespace TheOtherRoles
     }
 
 
-    public static class Medium {
+    public static class Medium
+    {
         public static PlayerControl medium;
         public static DeadPlayer target;
         public static DeadPlayer soulTarget;
@@ -1337,20 +1473,23 @@ namespace TheOtherRoles
         public static bool oneTimeUse = false;
 
         private static Sprite soulSprite;
-        public static Sprite getSoulSprite() {
+        public static Sprite getSoulSprite()
+        {
             if (soulSprite) return soulSprite;
             soulSprite = Helpers.loadSpriteFromResources("TheOtherRoles.Resources.Soul.png", 500f);
             return soulSprite;
         }
 
         private static Sprite question;
-        public static Sprite getQuestionSprite() {
+        public static Sprite getQuestionSprite()
+        {
             if (question) return question;
             question = Helpers.loadSpriteFromResources("TheOtherRoles.Resources.MediumButton.png", 115f);
             return question;
         }
 
-        public static void clearAndReload() {
+        public static void clearAndReload()
+        {
             medium = null;
             target = null;
             soulTarget = null;
@@ -1364,7 +1503,8 @@ namespace TheOtherRoles
         }
     }
 
-    public static class Lawyer {
+    public static class Lawyer
+    {
         public static PlayerControl lawyer;
         public static PlayerControl target;
         public static Color color = new Color32(134, 153, 25, byte.MaxValue);
@@ -1376,15 +1516,18 @@ namespace TheOtherRoles
         public static bool targetCanBeJester = false;
         public static bool targetWasGuessed = false;
 
-        public static Sprite getTargetSprite() {
+        public static Sprite getTargetSprite()
+        {
             if (targetSprite) return targetSprite;
             targetSprite = Helpers.loadSpriteFromResources("", 150f);
             return targetSprite;
         }
 
-        public static void clearAndReload(bool clearTarget = true) {
+        public static void clearAndReload(bool clearTarget = true)
+        {
             lawyer = null;
-            if (clearTarget) {
+            if (clearTarget)
+            {
                 target = null;
                 targetWasGuessed = false;
             }
@@ -1396,7 +1539,8 @@ namespace TheOtherRoles
         }
     }
 
-    public static class Pursuer {
+    public static class Pursuer
+    {
         public static PlayerControl pursuer;
         public static PlayerControl target;
         public static Color color = Lawyer.color;
@@ -1408,13 +1552,15 @@ namespace TheOtherRoles
         public static float cooldown = 30f;
         public static int blanksNumber = 5;
 
-        public static Sprite getTargetSprite() {
+        public static Sprite getTargetSprite()
+        {
             if (blank) return blank;
             blank = Helpers.loadSpriteFromResources("TheOtherRoles.Resources.PursuerButton.png", 115f);
             return blank;
         }
 
-        public static void clearAndReload() {
+        public static void clearAndReload()
+        {
             pursuer = null;
             target = null;
             blankedList = new List<PlayerControl>();
@@ -1426,7 +1572,8 @@ namespace TheOtherRoles
         }
     }
 
-    public static class Witch {
+    public static class Witch
+    {
         public static PlayerControl witch;
         public static Color color = Palette.ImpostorRed;
 
@@ -1442,21 +1589,24 @@ namespace TheOtherRoles
         public static bool witchVoteSavesTargets = true;
 
         private static Sprite buttonSprite;
-        public static Sprite getButtonSprite() {
+        public static Sprite getButtonSprite()
+        {
             if (buttonSprite) return buttonSprite;
             buttonSprite = Helpers.loadSpriteFromResources("TheOtherRoles.Resources.SpellButton.png", 115f);
             return buttonSprite;
         }
 
         private static Sprite spelledOverlaySprite;
-        public static Sprite getSpelledOverlaySprite() {
+        public static Sprite getSpelledOverlaySprite()
+        {
             if (spelledOverlaySprite) return spelledOverlaySprite;
             spelledOverlaySprite = Helpers.loadSpriteFromResources("TheOtherRoles.Resources.SpellButtonMeeting.png", 225f);
             return spelledOverlaySprite;
         }
 
 
-        public static void clearAndReload() {
+        public static void clearAndReload()
+        {
             witch = null;
             futureSpelled = new List<PlayerControl>();
             currentTarget = spellCastingTarget = null;
@@ -1470,7 +1620,8 @@ namespace TheOtherRoles
         }
     }
 
-    public static class Ninja {
+    public static class Ninja
+    {
         public static PlayerControl ninja;
         public static Color color = Palette.ImpostorRed;
 
@@ -1486,19 +1637,22 @@ namespace TheOtherRoles
         private static Sprite markButtonSprite;
         private static Sprite killButtonSprite;
         public static Arrow arrow = new Arrow(Color.black);
-        public static Sprite getMarkButtonSprite() {
+        public static Sprite getMarkButtonSprite()
+        {
             if (markButtonSprite) return markButtonSprite;
             markButtonSprite = Helpers.loadSpriteFromResources("TheOtherRoles.Resources.NinjaMarkButton.png", 115f);
             return markButtonSprite;
         }
 
-        public static Sprite getKillButtonSprite() {
+        public static Sprite getKillButtonSprite()
+        {
             if (killButtonSprite) return killButtonSprite;
             killButtonSprite = Helpers.loadSpriteFromResources("TheOtherRoles.Resources.NinjaAssassinateButton.png", 115f);
             return killButtonSprite;
         }
 
-        public static void clearAndReload() {
+        public static void clearAndReload()
+        {
             ninja = null;
             currentTarget = ninjaMarked = null;
             cooldown = CustomOptionHolder.ninjaCooldown.getFloat();
@@ -1514,7 +1668,8 @@ namespace TheOtherRoles
     }
 
     // Modifier
-    public static class Bait {
+    public static class Bait
+    {
         public static List<PlayerControl> bait = new List<PlayerControl>();
         public static Dictionary<DeadPlayer, float> active = new Dictionary<DeadPlayer, float>();
         public static Color color = new Color32(0, 247, 255, byte.MaxValue);
@@ -1523,7 +1678,8 @@ namespace TheOtherRoles
         public static float reportDelayMax = 0f;
         public static bool showKillFlash = true;
 
-        public static void clearAndReload() {
+        public static void clearAndReload()
+        {
             bait = new List<PlayerControl>();
             active = new Dictionary<DeadPlayer, float>();
             reportDelayMin = CustomOptionHolder.modifierBaitReportDelayMin.getFloat();
@@ -1533,14 +1689,16 @@ namespace TheOtherRoles
         }
     }
 
-    public static class Bloody {
+    public static class Bloody
+    {
         public static List<PlayerControl> bloody = new List<PlayerControl>();
         public static Dictionary<byte, float> active = new Dictionary<byte, float>();
         public static Dictionary<byte, byte> bloodyKillerMap = new Dictionary<byte, byte>();
 
         public static float duration = 5f;
 
-        public static void clearAndReload() {
+        public static void clearAndReload()
+        {
             bloody = new List<PlayerControl>();
             active = new Dictionary<byte, float>();
             bloodyKillerMap = new Dictionary<byte, byte>();
@@ -1548,47 +1706,57 @@ namespace TheOtherRoles
         }
     }
 
-    public static class AntiTeleport {
+    public static class AntiTeleport
+    {
         public static List<PlayerControl> antiTeleport = new List<PlayerControl>();
         public static Vector3 position;
 
-        public static void clearAndReload() {
+        public static void clearAndReload()
+        {
             antiTeleport = new List<PlayerControl>();
             position = Vector3.zero;
         }
 
-        public static void setPosition() {
+        public static void setPosition()
+        {
             if (position == Vector3.zero) return;  // Check if this has been set, otherwise first spawn on submerged will fail
-            if (antiTeleport.FindAll(x => x.PlayerId == CachedPlayer.LocalPlayer.PlayerId).Count > 0) {
+            if (antiTeleport.FindAll(x => x.PlayerId == CachedPlayer.LocalPlayer.PlayerId).Count > 0)
+            {
                 CachedPlayer.LocalPlayer.NetTransform.RpcSnapTo(position);
-                if (SubmergedCompatibility.IsSubmerged) {
+                if (SubmergedCompatibility.IsSubmerged)
+                {
                     SubmergedCompatibility.ChangeFloor(position.y > -7);
                 }
             }
         }
     }
 
-    public static class Tiebreaker {
+    public static class Tiebreaker
+    {
         public static PlayerControl tiebreaker;
 
         public static bool isTiebreak = false;
 
-        public static void clearAndReload() {
+        public static void clearAndReload()
+        {
             tiebreaker = null;
             isTiebreak = false;
         }
     }
 
-    public static class Sunglasses {
+    public static class Sunglasses
+    {
         public static List<PlayerControl> sunglasses = new List<PlayerControl>();
         public static int vision = 1;
 
-        public static void clearAndReload() {
+        public static void clearAndReload()
+        {
             sunglasses = new List<PlayerControl>();
             vision = CustomOptionHolder.modifierSunglassesVision.getSelection() + 1;
         }
     }
-    public static class Mini {
+    public static class Mini
+    {
         public static PlayerControl mini;
         public static Color color = Color.yellow;
         public const float defaultColliderRadius = 0.2233912f;
@@ -1598,42 +1766,49 @@ namespace TheOtherRoles
         public static DateTime timeOfGrowthStart = DateTime.UtcNow;
         public static bool triggerMiniLose = false;
 
-        public static void clearAndReload() {
+        public static void clearAndReload()
+        {
             mini = null;
             triggerMiniLose = false;
             growingUpDuration = CustomOptionHolder.modifierMiniGrowingUpDuration.getFloat();
             timeOfGrowthStart = DateTime.UtcNow;
         }
 
-        public static float growingProgress() {
+        public static float growingProgress()
+        {
             if (timeOfGrowthStart == null) return 0f;
 
             float timeSinceStart = (float)(DateTime.UtcNow - timeOfGrowthStart).TotalMilliseconds;
             return Mathf.Clamp(timeSinceStart / (growingUpDuration * 1000), 0f, 1f);
         }
 
-        public static bool isGrownUp() {
+        public static bool isGrownUp()
+        {
             return growingProgress() == 1f;
         }
 
     }
-    public static class Vip {
+    public static class Vip
+    {
         public static List<PlayerControl> vip = new List<PlayerControl>();
         public static bool showColor = true;
 
-        public static void clearAndReload() {
+        public static void clearAndReload()
+        {
             vip = new List<PlayerControl>();
             showColor = CustomOptionHolder.modifierVipShowColor.getBool();
         }
     }
 
-    public static class Invert {
+    public static class Invert
+    {
         public static List<PlayerControl> invert = new List<PlayerControl>();
         public static int meetings = 3;
 
-        public static void clearAndReload() {
+        public static void clearAndReload()
+        {
             invert = new List<PlayerControl>();
-            meetings = (int) CustomOptionHolder.modifierInvertDuration.getFloat();
+            meetings = (int)CustomOptionHolder.modifierInvertDuration.getFloat();
         }
     }
 }


### PR DESCRIPTION
With people joining and leaving regularly having dynamically assigned Impostor and VultureBodies based on the number of players removes the need to constantly monitor the number of players between rounds.

Instead of setting a fixed number of bodies to win its now floor(playerCount / 3.0).

Also displays the number of bodies eaten vs total needed to win in button for vulture