### PR TITLE
Add Option For Ninja and Morphling To Be Able To Vent

### DIFF
--- a/README.md
+++ b/README.md
@@ -660,28 +660,28 @@ docker run -d -p 22023:22023/udp --env IMPOSTOR_AntiCheatEnabled=false --env IMP
 
 
 # Credits & Resources
-[OxygenFilter](https://github.com/NuclearPowered/Reactor.OxygenFilter) - For all the version v2.3.0 to v2.6.1, we were using the OxygenFilter for automatic deobfuscation\
-[Reactor](https://github.com/NuclearPowered/Reactor) - The framework used for all version before v2.0.0\
-[BepInEx](https://github.com/BepInEx) - Used to hook game functions\
+[OxygenFilter](https://github.com/NuclearPowered/Reactor.OxygenFilter) - For all the versions between v2.3.0 and v2.6.1, we were using the OxygenFilter for automatic deobfuscation\
+[Reactor](https://github.com/NuclearPowered/Reactor) - The framework used for all versions before v2.0.0\
+[BepInEx](https://github.com/BepInEx) - Used to hook to game functions\
 [Essentials](https://github.com/DorCoMaNdO/Reactor-Essentials) - Custom game options by **DorCoMaNdO**:
 - Before v1.6: We used the default Essentials release
-- v1.6-v1.8: We slightly changed the default Essentials. The changes can be found on this [branch](https://github.com/Eisbison/Reactor-Essentials/tree/feature/TheOtherRoles-Adaption) of our fork.
-- v2.0.0 and later: As we're not using Reactor anymore, we are using our own implementation, inspired by the one from **DorCoMaNdO**
+- v1.6-v1.8: We slightly changed the default Essentials release. The changes can be found on this [branch](https://github.com/Eisbison/Reactor-Essentials/tree/feature/TheOtherRoles-Adaption) of our fork.
+- v2.0.0 and later: We're no longer using Reactor anymore we are using our own implementation inspired by the one from **DorCoMaNdO**
 
-[Jackal and Sidekick](https://www.twitch.tv/dhalucard) - Original idea for the Jackal and Sidekick comes from **Dhalucard**\
-[Among-Us-Love-Couple-Mod](https://github.com/Woodi-dev/Among-Us-Love-Couple-Mod) - Idea for the Lovers role comes from **Woodi-dev**\
-[Jester](https://github.com/Maartii/Jester) - Idea for the Jester role comes from **Maartii**\
-[ExtraRolesAmongUs](https://github.com/NotHunter101/ExtraRolesAmongUs) - Idea for the Engineer and Medic role comes from **NotHunter101**. Also some code snippets come of the implementation were used.\
-[Among-Us-Sheriff-Mod](https://github.com/Woodi-dev/Among-Us-Sheriff-Mod) - Idea for the Sheriff role comes from **Woodi-dev**\
-[TooManyRolesMods](https://github.com/Hardel-DW/TooManyRolesMods) - Idea for the Detective and Time Master roles comes from **Hardel-DW**. Also some code snippets of the implementation were used.\
-[TownOfUs](https://github.com/slushiegoose/Town-Of-Us) - Idea for the Swapper, Shifter, Arsonist and a similar Mayor role come from **Slushiegoose**\
-[Ottomated](https://twitter.com/ottomated_) - Idea for the Morphling, Snitch and Camouflager role come from **Ottomated**\
+[Jackal and Sidekick](https://www.twitch.tv/dhalucard) - Original idea for the Jackal and Sidekick came from **Dhalucard**\
+[Among-Us-Love-Couple-Mod](https://github.com/Woodi-dev/Among-Us-Love-Couple-Mod) - Idea for the Lovers modifier came from **Woodi-dev**\
+[Jester](https://github.com/Maartii/Jester) - Idea for the Jester role came from **Maartii**\
+[ExtraRolesAmongUs](https://github.com/NotHunter101/ExtraRolesAmongUs) - Idea for the Engineer and Medic role came from **NotHunter101**. Also some code snippets from their implementation were used.\
+[Among-Us-Sheriff-Mod](https://github.com/Woodi-dev/Among-Us-Sheriff-Mod) - Idea for the Sheriff role came from **Woodi-dev**\
+[TooManyRolesMods](https://github.com/Hardel-DW/TooManyRolesMods) - Idea for the Detective and Time Master roles came from **Hardel-DW**. Also some code snippets from their implementation were used.\
+[TownOfUs](https://github.com/slushiegoose/Town-Of-Us) - Idea for the Swapper, Shifter, Arsonist, and a similar Mayor role came from **Slushiegoose**\
+[Ottomated](https://twitter.com/ottomated_) - Idea for the Morphling, Snitch and Camouflager role came from **Ottomated**\
 [Crowded-Mod](https://github.com/CrowdedMods/CrowdedMod) - Our implementation for 10+ player lobbies is inspired by the one from the **Crowded Mod Team**\
-[Goose-Goose-Duck](https://store.steampowered.com/app/1568590/Goose_Goose_Duck) - Idea for the Vulture role come from **Slushygoose**
+[Goose-Goose-Duck](https://store.steampowered.com/app/1568590/Goose_Goose_Duck) - Idea for the Vulture role came from **Slushiegoose**
 
 # Settings
 The mod adds a few new settings to Among Us (in addition to the role settings):
-- **Streamer Mode:** You can activate the streamer mode in the Among Us settings. It hides the lobby code, the custom server ip and the custom server port. You can set a custom lobby code replacement text, by changing the *Streamer Mode Replacement Text* in the `BepInEx\config\me.eisbison.theotherroles.cfg` file.
+- **Streamer Mode:** You can activate the streamer mode in the Among Us settings. It hides the lobby code, the custom server IP and the custom server port. You can set a custom lobby code replacement text, by changing the *Streamer Mode Replacement Text* in the `BepInEx\config\me.eisbison.theotherroles.cfg` file.
 - **Number of Crewmates:** The number of Crewmate roles can be set inside a lobby.
 - **Number of Neutrals:** The number of Neutral roles can be set inside a lobby.
 - **Number of Impostors:** The number of Impostor roles can be set inside a lobby.
@@ -803,6 +803,7 @@ The Morphling is an Impostor which can additionally scan the appearance of a pla
 | Morphling Spawn Chance | -
 | Morphling Cooldown | -
 | Morph Duration | Time the Morphling stays morphed
+| Morphling Can Use Vents | Yes/No |
 -----------------------
 
 ## Camouflager
@@ -997,6 +998,7 @@ When performing a ninja ability kill, the ninja can be invisible for some second
 | Trace Duration | -
 | Time Till Trace Color Has Faded | -
 | Time The Ninja Is Invisible | -
+| Ninja Can Use Vents | Yes/No |
 -----------------------
 
 ## Guesser

--- a/TheOtherRoles/CustomOptionHolder.cs
+++ b/TheOtherRoles/CustomOptionHolder.cs
@@ -26,6 +26,7 @@ namespace TheOtherRoles {
         public static CustomOption morphlingSpawnRate;
         public static CustomOption morphlingCooldown;
         public static CustomOption morphlingDuration;
+        public static CustomOption morphlingCanUseVents;
 
         public static CustomOption camouflagerSpawnRate;
         public static CustomOption camouflagerCooldown;
@@ -90,6 +91,7 @@ namespace TheOtherRoles {
         public static CustomOption ninjaTraceTime;
         public static CustomOption ninjaTraceColorTime;
         public static CustomOption ninjaInvisibleDuration;
+        public static CustomOption ninjaCanUseVents;
 
         public static CustomOption shifterSpawnRate;
         public static CustomOption shifterShiftsModifiers;
@@ -311,6 +313,7 @@ namespace TheOtherRoles {
             morphlingSpawnRate = CustomOption.Create(20, Types.Impostor, cs(Morphling.color, "Morphling"), rates, null, true);
             morphlingCooldown = CustomOption.Create(21, Types.Impostor, "Morphling Cooldown", 30f, 10f, 60f, 2.5f, morphlingSpawnRate);
             morphlingDuration = CustomOption.Create(22, Types.Impostor, "Morph Duration", 10f, 1f, 20f, 0.5f, morphlingSpawnRate);
+            morphlingCanUseVents = CustomOption.Create(23, Types.Impostor, "Morphling Can Use Vents", true, morphlingSpawnRate);
 
             camouflagerSpawnRate = CustomOption.Create(30, Types.Impostor, cs(Camouflager.color, "Camouflager"), rates, null, true);
             camouflagerCooldown = CustomOption.Create(31, Types.Impostor, "Camouflager Cooldown", 30f, 10f, 60f, 2.5f, camouflagerSpawnRate);
@@ -358,6 +361,7 @@ namespace TheOtherRoles {
             ninjaTraceTime = CustomOption.Create(383, Types.Impostor, "Trace Duration", 5f, 1f, 20f, 0.5f, ninjaSpawnRate);
             ninjaTraceColorTime = CustomOption.Create(384, Types.Impostor, "Time Till Trace Color Has Faded", 2f, 0f, 20f, 0.5f, ninjaSpawnRate);
             ninjaInvisibleDuration = CustomOption.Create(385, Types.Impostor, "Time The Ninja Is Invisible", 3f, 0f, 20f, 1f, ninjaSpawnRate);
+            ninjaCanUseVents = CustomOption.Create(386, Types.Impostor, "Ninja Can Use Vents", true, ninjaSpawnRate);
 
             guesserSpawnRate = CustomOption.Create(310, Types.Neutral, cs(Guesser.color, "Guesser"), rates, null, true);
             guesserIsImpGuesserRate = CustomOption.Create(311, Types.Neutral, "Chance That The Guesser Is An Impostor", rates, guesserSpawnRate);

--- a/TheOtherRoles/Helpers.cs
+++ b/TheOtherRoles/Helpers.cs
@@ -322,14 +322,14 @@ namespace TheOtherRoles {
                 roleCouldUse = true;
             else if (Vulture.canUseVents && Vulture.vulture != null && Vulture.vulture == player)
                 roleCouldUse = true;
-            else if (Morphling.canUseVents && Morphling.morphling != null && Morphling.morphling == player)
-                roleCouldUse = true;
-            else if (Ninja.canUseVents && Ninja.ninja != null && Ninja.ninja == player)
-                roleCouldUse = true;
             else if (player.Data?.Role != null && player.Data.Role.CanVent)  {
                 if (Janitor.janitor != null && Janitor.janitor == CachedPlayer.LocalPlayer.PlayerControl)
                     roleCouldUse = false;
                 else if (Mafioso.mafioso != null && Mafioso.mafioso == CachedPlayer.LocalPlayer.PlayerControl && Godfather.godfather != null && !Godfather.godfather.Data.IsDead)
+                    roleCouldUse = false;
+                else if (!Ninja.canUseVents && Ninja.ninja != null && Ninja.ninja == player)
+                    roleCouldUse = false;
+                else if (!Morphling.canUseVents && Morphling.morphling != null && Morphling.morphling == player)
                     roleCouldUse = false;
                 else
                     roleCouldUse = true;

--- a/TheOtherRoles/Helpers.cs
+++ b/TheOtherRoles/Helpers.cs
@@ -68,7 +68,7 @@ namespace TheOtherRoles {
         }
 
         public static AudioClip loadAudioClipFromResources(string path, string clipName = "UNNAMED_TOR_AUDIO_CLIP") {
-            // must be "raw (headerless) 2-channel signed 32 bit pcm (le)" (can e.g. use Audacity® to export)
+            // must be "raw (headerless) 2-channel signed 32 bit pcm (le)" (can e.g. use Audacityï¿½ to export)
             try {
                 Assembly assembly = Assembly.GetExecutingAssembly();
                 Stream stream = assembly.GetManifestResourceStream(path);
@@ -321,6 +321,10 @@ namespace TheOtherRoles {
             else if (Spy.canEnterVents && Spy.spy != null && Spy.spy == player)
                 roleCouldUse = true;
             else if (Vulture.canUseVents && Vulture.vulture != null && Vulture.vulture == player)
+                roleCouldUse = true;
+            else if (Morphling.canUseVents && Morphling.morphling != null && Morphling.morphling == player)
+                roleCouldUse = true;
+            else if (Ninja.canUseVents && Ninja.ninja != null && Ninja.ninja == player)
                 roleCouldUse = true;
             else if (player.Data?.Role != null && player.Data.Role.CanVent)  {
                 if (Janitor.janitor != null && Janitor.janitor == CachedPlayer.LocalPlayer.PlayerControl)

--- a/TheOtherRoles/TheOtherRoles.cs
+++ b/TheOtherRoles/TheOtherRoles.cs
@@ -570,6 +570,7 @@ namespace TheOtherRoles
         public static PlayerControl sampledTarget;
         public static PlayerControl morphTarget;
         public static float morphTimer = 0f;
+        public static bool canUseVents = true;
 
         public static void resetMorph() {
             morphTarget = null;
@@ -585,6 +586,7 @@ namespace TheOtherRoles
             sampledTarget = null;
             morphTarget = null;
             morphTimer = 0f;
+            canUseVents = CustomOptionHolder.morphlingCanUseVents.getBool();
             cooldown = CustomOptionHolder.morphlingCooldown.getFloat();
             duration = CustomOptionHolder.morphlingDuration.getFloat();
         }
@@ -1481,6 +1483,7 @@ namespace TheOtherRoles
         public static float traceTime = 1f;
         public static bool knowsTargetLocation = false;
         public static float invisibleDuration = 5f;
+        public static bool canUseVents = true;
 
         public static float invisibleTimer = 0f;
         public static bool isInvisble = false;
@@ -1506,6 +1509,7 @@ namespace TheOtherRoles
             knowsTargetLocation = CustomOptionHolder.ninjaKnowsTargetLocation.getBool();
             traceTime = CustomOptionHolder.ninjaTraceTime.getFloat();
             invisibleDuration = CustomOptionHolder.ninjaInvisibleDuration.getFloat();
+            canUseVents = CustomOptionHolder.ninjaCanUseVents.getBool();
             invisibleTimer = 0f;
             isInvisble = false;
             if (arrow?.arrow != null) UnityEngine.Object.Destroy(arrow.arrow);


### PR DESCRIPTION
Make venting as Ninja and Morphling an optional setting. Most players do not agree with these roles being able to vent and consider it too 'overpowered.' TownOfUs by default does not not allow the Morphling or Swooper (Ninja) to be able to vent and provides an option to enable it.

This is more of a balance patch as, when playing, the Morphling and Ninja can just vent away and get off scotch-free for everything. 