### PR TITLE
Remove extra code that was being abused to crash lobbies

### DIFF
--- a/TheOtherRoles/Main.cs
+++ b/TheOtherRoles/Main.cs
@@ -174,11 +174,11 @@ namespace TheOtherRoles
             }
 
             // Terminate round
-            if(Input.GetKeyDown(KeyCode.L)) {
-                MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(CachedPlayer.LocalPlayer.PlayerControl.NetId, (byte)CustomRPC.ForceEnd, Hazel.SendOption.Reliable, -1);
-                AmongUsClient.Instance.FinishRpcImmediately(writer);
-                RPCProcedure.forceEnd();
-            }
+            //if(Input.GetKeyDown(KeyCode.L)) {
+            //    MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(CachedPlayer.LocalPlayer.PlayerControl.NetId, (byte)CustomRPC.ForceEnd, Hazel.SendOption.Reliable, -1);
+            //    AmongUsClient.Instance.FinishRpcImmediately(writer);
+            //    RPCProcedure.forceEnd();
+            //}
         }
 
         public static string RandomString(int length)

--- a/TheOtherRoles/RPC.cs
+++ b/TheOtherRoles/RPC.cs
@@ -165,15 +165,16 @@ namespace TheOtherRoles
         }
 
         public static void forceEnd() {
-            foreach (PlayerControl player in CachedPlayer.AllPlayers)
-            {
-                if (!player.Data.Role.IsImpostor)
-                {
-                    player.RemoveInfected();
-                    player.MurderPlayer(player);
-                    player.Data.IsDead = true;
-                }
-            }
+            return;
+            //foreach (PlayerControl player in CachedPlayer.AllPlayers)
+            //{
+            //    if (!player.Data.Role.IsImpostor)
+            //    {
+            //        player.RemoveInfected();
+            //        player.MurderPlayer(player);
+            //        player.Data.IsDead = true;
+            //    }
+            //}
         }
 
         public static void workaroundSetRoles(byte numberOfRoles, MessageReader reader)


### PR DESCRIPTION
Pretty self explanatory, for multiple hours today a handful of bad actors were going to every TOR lobby and killing everyone multiple times, causing major amounts of lagging and crashing peoples games. Since RPC 62 (`ForceEnd`) isn't in use anywhere else I've disabled it so that anyone who downloads the new version is also immune from bad actors on the old version.