### PR TITLE
Fix Trapper Info

### DIFF
--- a/TheOtherRoles/Objects/Trap.cs
+++ b/TheOtherRoles/Objects/Trap.cs
@@ -7,6 +7,11 @@ using TheOtherRoles.Utilities;
 using UnityEngine;
 
 namespace TheOtherRoles.Objects {
+    record TrapInfo {
+        public PlayerControl player;
+        public string roleWhenInTrap;
+    }
+    
     class Trap {
         public static List<Trap> traps = new List<Trap>();
         public static Dictionary<byte, Trap> trapPlayerIdMap = new Dictionary<byte, Trap>();
@@ -18,7 +23,7 @@ namespace TheOtherRoles.Objects {
         public bool triggerable = false;
         private int usedCount = 0;
         private int neededCount = Trapper.trapCountToReveal;
-        public List<PlayerControl> trappedPlayer = new List<PlayerControl>();
+        public List<TrapInfo> trappedPlayer = new List<TrapInfo>();
         private Arrow arrow = new Arrow(Color.blue);
 
         private static Sprite trapSprite;
@@ -95,11 +100,12 @@ namespace TheOtherRoles.Objects {
                 }
             })));
 
-            if (t.usedCount == t.neededCount) {
+            if (t.usedCount == t.neededCount)
+            {
                 t.revealed = true;
             }
-
-            t.trappedPlayer.Add(player);
+            
+            t.trappedPlayer.Add(new TrapInfo { player = player, roleWhenInTrap = RoleInfo.GetRolesString(player, false, false, true)});
             t.triggerable = true;
 
         }
@@ -115,7 +121,7 @@ namespace TheOtherRoles.Objects {
             Trap target = null;
             foreach (Trap trap in traps) {
                 if (trap.arrow.arrow.active) trap.arrow.Update();
-                if (trap.revealed || !trap.triggerable || trap.trappedPlayer.Contains(player.PlayerControl)) continue;
+                if (trap.revealed || !trap.triggerable || trap.trappedPlayer.Any(tp => tp.player == player.PlayerControl)) continue;
                 if (player.PlayerControl.inVent || !player.PlayerControl.CanMove) continue;
                 float distance = Vector2.Distance(trap.trap.transform.position, player.PlayerControl.GetTruePosition());
                 if (distance <= ud && distance < closestDistance) {

--- a/TheOtherRoles/Patches/MeetingPatch.cs
+++ b/TheOtherRoles/Patches/MeetingPatch.cs
@@ -717,8 +717,10 @@ namespace TheOtherRoles.Patches {
                         if (!trap.revealed) continue;
                         string message = $"Trap {trap.instanceId}: \n";
                         trap.trappedPlayer = trap.trappedPlayer.OrderBy(x => rnd.Next()).ToList();
-                        foreach (PlayerControl p in trap.trappedPlayer) {
-                            if (Trapper.infoType == 0) message += RoleInfo.GetRolesString(p, false, false, true) + "\n";
+                        foreach (TrapInfo trapInfo in trap.trappedPlayer)
+                        {
+                            PlayerControl p = trapInfo.player;
+                            if (Trapper.infoType == 0) message += trapInfo.roleWhenInTrap + "\n";
                             else if (Trapper.infoType == 1) {
                                 if (Helpers.isNeutral(p) || p.Data.Role.IsImpostor) message += "Evil Role \n";
                                 else message += "Good Role \n";


### PR DESCRIPTION
> The way it is now:

The trapper gets his information about the players from the traps at the time the meeting starts (or when the chat is available).

The problem with this is that if a player in the trap gets a sidekick, the trapper will magically see the sidekick in the meeting and not the player's role when they were in the trap.

> What the PR changes:

Since the trapper receives their information via the trap, they should not notice any subsequent changes. With the PR, the trapper receives the role information about the player at the time in the trap.